### PR TITLE
Add opencode skills and refresh per-package guidelines

### DIFF
--- a/.opencode/skills/add-error-code/SKILL.md
+++ b/.opencode/skills/add-error-code/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: add-error-code
+description: Use when adding a new ErrorCode to packages/constants, updating the ErrorMessage map, or adding a rate-limit tier. Covers the ErrorCode enum + ErrorMessage {log,notice} pairing rule, NodeErrorMessage, and rateLimitConfigs. Trigger keywords: "error code", "ErrorMessage", "rate limit config", "constants".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: constants
+  stack: tsup,typescript
+---
+
+<Goal>
+
+Add a new runtime error contract or rate-limit tier to `packages/constants`
+while keeping the package framework-free and every `ErrorCode` paired with its
+`ErrorMessage`.
+
+</Goal>
+
+<Scope>
+
+- Package: `packages/constants`
+- Files:
+  - `src/errors/code.ts` — `ErrorCode` numeric enum
+  - `src/errors/message.ts` — `ErrorMessage` map + `NodeErrorMessage` map
+  - `src/errors/index.ts` — barrel (re-exports `./code` + `./message`)
+  - `src/ratelimitConfigs.ts` — `RateLimitConfig` interface + `rateLimitConfigs`
+  - `src/index.ts` — root barrel (`export * from './errors'; export * from './ratelimitConfigs'`)
+- Full conventions: see `packages/constants/AGENTS.md` (always loaded).
+
+</Scope>
+
+<Steps>
+
+### Case A: New ErrorCode
+
+1. **Append to the enum** in `src/errors/code.ts`. Numeric values are
+   auto-assigned — **never renumber existing codes**; append at the end of the
+   relevant domain group. Add a comment header for a new domain group:
+   ```ts
+   export enum ErrorCode {
+     // General
+     General = 0,
+     InvalidBody,
+     // Auth
+     Unauthorized = 100,
+     ...
+   }
+   ```
+2. **Add the matching ErrorMessage** in `src/errors/message.ts`. An orphan
+   code or message is a bug — `ErrorMessage: Record<ErrorCode, ErrorMessage>`
+   must cover every code:
+   ```ts
+   const Unauthorized = {
+     log: '...',
+     notice: '...',
+   } as const;
+
+   export const ErrorMessage: Record<ErrorCode, ErrorMessage> = {
+     ...,
+     [ErrorCode.Unauthorized]: Unauthorized,
+   } as const;
+   ```
+3. **`ErrorMessage` shape**: `{ log: string; notice: string } as const`.
+   - `log` — diagnostic text for server logs (detailed, implementation-facing).
+   - `notice` — user-safe text shown in the UI (generic, no internals).
+4. The barrel `src/errors/index.ts` already re-exports `./code` + `./message`;
+   no change needed unless you add a new file.
+
+### Case B: Non-ErrorCode runtime error
+
+- Add to `NodeErrorMessage: Record<'NodeError' | 'UnknownError', ErrorMessage>`
+  in `src/errors/message.ts`. Keep it separate from `ErrorMessage` — it holds
+  errors that aren't part of the `ErrorCode` enum (e.g. generic Node failures).
+
+### Case C: New rate-limit tier
+
+1. Add a named tier to `rateLimitConfigs` in `src/ratelimitConfigs.ts`:
+   ```ts
+   export const rateLimitConfigs = {
+     strict: { windowMs: 60_000, maxRequests: 10 },
+     ...,
+     // new tier
+     upload: { windowMs: 60_000, maxRequests: 5, skipSuccessfulRequests: true },
+   } as const;
+   ```
+2. Each entry must match `RateLimitConfig { windowMs, maxRequests,
+   skipSuccessfulRequests?, skipFailedRequests? }`. Use `as const` for narrow
+   literal types.
+
+### Case D: Export-only
+
+- Export through the nearest barrel (`errors/index.ts`, then `src/index.ts`).
+- Import from `@workspace/constants` (the root), not deep paths.
+- Don't duplicate these constants in `apps/web`; import them.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.packages.constants` — ESLint `--max-warnings 0`
+- `nps typecheck.packages.constants` — `tsc --noEmit`
+- `nps build.packages.constants` — `tsup` build
+- Cross-check: `Object.keys(ErrorMessage)` length === `Object.keys(ErrorCode)`
+  length (no orphans).
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT renumber existing `ErrorCode` values — they are part of the wire
+  contract; appending only.
+- Do NOT add an `ErrorCode` without its `ErrorMessage` (or vice versa).
+- Do NOT import React/Next/framework code here — runtime constants only.
+- Do NOT duplicate these constants in `apps/web`.
+
+</AntiPatterns>

--- a/.opencode/skills/add-next-route/SKILL.md
+++ b/.opencode/skills/add-next-route/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: add-next-route
+description: Use when adding a new Next.js App Router route or route group to apps/web (page.tsx, layout.tsx, loading.tsx, route groups). Covers async server components, PageProps/LayoutProps from @workspace/types/web, awaiting Promise params/searchParams, route-local components, and the (global-not-found) 404 group. Trigger keywords: "new route", "page.tsx", "layout.tsx", "App Router", "route group", "Next 16".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: web
+  stack: nextjs-16,react-19,rsc,app-router
+---
+
+<Goal>
+
+Add a new route (or route group) to `apps/web` using the Next.js 16 App Router,
+keeping server components as the default, awaiting `Promise<...>` params, and
+co-locating route-specific components.
+
+</Goal>
+
+<Scope>
+
+- App: `apps/web`, under `src/app/`
+- Route file types: `page.tsx`, `layout.tsx`, `loading.tsx` (optional),
+  `not-found.tsx` (do NOT add top-level — use the existing route group)
+- Full conventions: see `apps/web/AGENTS.md` (always loaded).
+- Reference routes: `src/app/page.tsx`, `src/app/layout.tsx`,
+  `src/app/(global-not-found)/index.tsx`.
+
+</Scope>
+
+<Steps>
+
+1. **Create the route folder** under `src/app/`. Route groups use parenthesised
+   names: `src/app/(<group>)/...` (e.g. `(auth)`, `(member)`). Dynamic segments
+   use `[<param>]`.
+
+2. **Add `page.tsx`** as an async server component. Props come from
+   `@workspace/types/web` (`PageProps`), and `params` / `searchParams` are
+   `Promise<...>` — always `await` them:
+   ```tsx
+   import type { PageProps } from '@workspace/types/web';
+
+   export default async function MyPage({
+     params,
+     searchParams,
+   }: PageProps<{ slug: string }>) {
+     const { slug } = await params;
+     const sp = await searchParams;
+     // ...
+   }
+   ```
+   (If you need a custom params shape, see `SingleParam` / `DinamicParams` /
+   `Params` in `packages/types/src/web/layout.ts`.)
+
+3. **Add `layout.tsx`** when the route needs shared UI or data. Props are
+   `LayoutProps` from `@workspace/types/web`:
+   ```tsx
+   import type { LayoutProps } from '@workspace/types/web';
+
+   export default async function MyLayout({ children, params }: LayoutProps) {
+     const { slug } = await params;
+     return <section>{children}</section>;
+   }
+   ```
+
+4. **Keep server components the default.** Only mark `'use client'` when you
+   need browser APIs, hooks, context, or providers (see
+   `src/components/Providers/*.tsx`).
+
+5. **Co-locate route-specific components** in:
+   - `src/app/components/` for shared root-level pieces (e.g. `Header`,
+     `Section`), OR
+   - `src/app/<route>/components/` for route-local pieces.
+   Promote to `@workspace/ui` only when a second package consumes them.
+
+6. **404 handling**: do NOT add a top-level `not-found.tsx`. The
+   `(global-not-found)` route group renders `GlobalNotFoundContent`
+   (`src/app/(global-not-found)/index.tsx`). Extend that group if you need
+   route-specific not-found UI inside a nested layout.
+
+7. **Import UI via subpaths**: `@workspace/ui/components/<name>`,
+   `@workspace/ui/lib/utils` (for `cn`). Never deep-import via relative paths.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.web` — ESLint `--max-warnings 0`
+- `nps typecheck.web` — `tsc --noEmit`
+- `nps build.web` — `next build` (validates the route compiles)
+- `nps dev.web` — `next dev` to smoke-test in the browser
+- Add a test under `src/tests/` for any non-trivial page (see the
+  `add-web-test` skill).
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT make `params` / `searchParams` synchronous — Next 16 + React 19 pass
+  them as `Promise<...>`. Always `await`.
+- Do NOT add a top-level `not-found.tsx` — extend the `(global-not-found)`
+  group instead.
+- Do NOT default to `'use client'` for pages/layouts — server components are
+  the default; add the directive only when needed.
+- Do NOT deep-import UI via relative paths — use the `@workspace/ui/*`
+  subpaths.
+
+</AntiPatterns>

--- a/.opencode/skills/add-redux-slice/SKILL.md
+++ b/.opencode/skills/add-redux-slice/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: add-redux-slice
+description: Use when adding a new Redux Toolkit slice to apps/web (e.g. a counter, cart, or feature state). Covers createSlice in store/slices, default-exporting the reducer, named-exporting actions, registering in store/index.ts, and using the typed hooks useAppDispatch/useAppSelector. Trigger keywords: "Redux slice", "createSlice", "useAppDispatch", "useAppSelector", "store reducer".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: web
+  stack: redux-toolkit,react-redux,react19
+---
+
+<Goal>
+
+Add a new Redux Toolkit slice to `apps/web` for client-side state, wire it into
+the store, and consume it through the project's typed hooks — never raw
+`useDispatch`/`useSelector`.
+
+</Goal>
+
+<Scope>
+
+- App: `apps/web`
+- Files:
+  - `src/store/slices/<name>.ts` — new slice (create this)
+  - `src/store/index.ts` — register reducer + (already exports typed hooks)
+- Full conventions: see `apps/web/AGENTS.md` (always loaded).
+- Reference: `src/store/slices/counter.ts` is the canonical example.
+
+</Scope>
+
+<Steps>
+
+1. **Create the slice** in `src/store/slices/<name>.ts`, mirroring
+   `counter.ts`:
+   ```ts
+   import { createSlice } from '@reduxjs/toolkit';
+
+   type <Name>State = { /* ... */ };
+
+   const initialState = { /* ... */ } as <Name>State;
+
+   const <name> = createSlice({
+     name: '<name>',
+     initialState,
+     reducers: {
+       reset: () => initialState,
+       // mutative drafts are fine — Immer is in use
+       someAction: (state, action) => { state.x = action.payload; },
+     },
+   });
+
+   export const { someAction, reset } = <name>.actions;
+   export default <name>.reducer;
+   ```
+2. **Default-export the reducer**, **named-export the actions** (matches
+   `counter.ts:25-27`).
+3. **Register the reducer** in `src/store/index.ts`:
+   ```ts
+   import <name>Reducer from './slices/<name>';
+
+   export const store = configureStore({
+     reducer: {
+       counter: counterReducer,
+       <name>: <name>Reducer,
+     },
+   });
+   ```
+4. **Typed hooks already exist** in `src/store/index.ts` — do NOT recreate
+   them:
+   - `useAppDispatch` (typed `AppDispatch`)
+   - `useAppSelector` (typed `RootState`)
+   Import them from `@/store`, never raw `useDispatch`/`useSelector` from
+   `react-redux`.
+5. **Consume in a client component** (`'use client'`):
+   ```tsx
+   'use client';
+   import { useAppDispatch, useAppSelector } from '@/store';
+   import { someAction } from '@/store/slices/<name>';
+   ```
+6. Slices are client-side only — the store is provided via
+   `ReduxToolProvider` in `src/components/Providers/ReduxTool.tsx`, which is
+   mounted in `app/layout.tsx`. Server components cannot read the store.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.web` — ESLint `--max-warnings 0`
+- `nps typecheck.web` — `tsc --noEmit`
+- `nps build.web` — `next build`
+- `nps test.web` — Vitest run (add a test if the slice has non-trivial logic;
+  see the `add-web-test` skill)
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT use raw `useDispatch` / `useSelector` — they lose type safety. Use
+  `useAppDispatch` / `useAppSelector` from `@/store`.
+- Do NOT export the reducer as a named export — default-export it (matches
+  `counter.ts` and the `import <name>Reducer from './slices/<name>'` pattern).
+- Do NOT try to access the store from a server component — Redux is
+  client-side only in this setup.
+- Do NOT recreate `configureStore` or the typed hooks — they live in
+  `src/store/index.ts` only.
+
+</AntiPatterns>

--- a/.opencode/skills/add-shared-type/SKILL.md
+++ b/.opencode/skills/add-shared-type/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: add-shared-type
+description: Use when adding a cross-package type to packages/types (e.g. a new Next.js App Router helper type, or a shared contract consumed by both apps/web and a future package). Covers the type-only package rules, ./web subpath exports, and PageProps/LayoutProps conventions. Trigger keywords: "shared type", "PageProps", "LayoutProps", "SearchParams", "@workspace/types/web".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: types
+  stack: typescript,tsc
+---
+
+<Goal>
+
+Add a shared TypeScript type to `packages/types` that crosses a real package
+boundary, while keeping the package type-only and free of runtime/framework
+code.
+
+</Goal>
+
+<Scope>
+
+- Package: `packages/types`
+- Files:
+  - `src/web/page.ts` — `PageProps`, `SearchParams`
+  - `src/web/layout.ts` — `LayoutProps`, `Params`, `SingleParam`, `DinamicParams`
+  - `src/web/index.ts` — barrel (`export * from './page'; export * from './layout'`)
+- Exports (keep in sync with `package.json`):
+  - `@workspace/types/web` → `./src/web/*`
+  - `@workspace/types` → root (reserved for future cross-package types)
+- Full conventions: see `packages/types/AGENTS.md` (always loaded).
+- Keep **app-local** types in `apps/web/src/types/`. Promote here only when a
+  real cross-package boundary exists.
+
+</Scope>
+
+<Steps>
+
+1. **Decide if it belongs here.** Add a shared type ONLY when:
+   - It is consumed by `apps/web` AND at least one other package, OR
+   - It documents a Next.js App Router contract shared across packages.
+   Otherwise keep it in `apps/web/src/types/`.
+
+2. **Pick `interface` vs `type`**:
+   - `interface` for object contracts (props, options, configs).
+   - `type` alias for unions, mapped types, utility types.
+
+3. **For a Next.js App Router page/layout helper** (the current surface),
+   follow `src/web/page.ts` / `src/web/layout.ts`:
+   - `params` and `searchParams` are `Promise<...>` per React 19 / Next 16 —
+     do NOT make them synchronous.
+   - `SearchParams = Promise<{ [key: string]: string | string[] | undefined }>`
+   - `PageProps = Omit<LayoutProps, 'children'> & { searchParams: SearchParams }`
+   - Use `import type` for any imports (this is a type-only package).
+
+4. **Add the type** in the appropriate `src/web/<file>.ts`, then re-export via
+   `src/web/index.ts` if not already covered by `export *`.
+
+5. **Don't import runtime packages here.** The package may depend on
+   `@workspace/constants` for typing constants but nothing framework-specific.
+
+6. **Ignore `dist/`** — it is `tsc` build output. Edit source in `src/` only.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.packages.types` — ESLint `--ext .ts --max-warnings 0`
+- `nps typecheck.packages.types` — `tsc --noEmit`
+- `nps build.packages.types` — `tsc -p tsconfig.json` (emits `dist/`)
+- Consume from `apps/web`: `import type { PageProps } from '@workspace/types/web'`
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT add runtime values, validation, or React/Next code — type-only.
+- Do NOT make `params` / `searchParams` synchronous — Next 16 + React 19
+  require `Promise<...>`.
+- Do NOT add a type here that only `apps/web` uses — keep it app-local.
+- Do NOT import framework packages here (React, Next, Radix, ...). Only
+  `@workspace/constants` for constant typing is allowed.
+- Do NOT edit `dist/` — it is build output.
+
+</AntiPatterns>

--- a/.opencode/skills/add-ui-component/SKILL.md
+++ b/.opencode/skills/add-ui-component/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: add-ui-component
+description: Use when adding a new shared React primitive (component, hook, or utility) to packages/ui. Covers shadcn "new-york" style, Radix primitives, CVA variants, Tailwind v4, and subpath exports. Trigger keywords: "add component", "new ui primitive", "shadcn add", "Radix", "CVA variant".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: ui
+  stack: shadcn,radix,cva,tailwind-v4,lucide,next-themes,sonner
+---
+
+<Goal>
+
+Add a reusable React primitive to `packages/ui` that `apps/web` (and future
+packages) can import via subpath exports. The result must be RSC-safe by
+default, follow shadcn "new-york" conventions, and export through the existing
+subpath scheme.
+
+</Goal>
+
+<Scope>
+
+- Package: `packages/ui`
+- Files touched: `src/components/<name>.tsx`, `src/hooks/<name>.ts`, or
+  `src/lib/<name>.ts`
+- DO NOT add route-specific UI here — keep that in `apps/web`. Promote to this
+  package only when a second consumer appears.
+- Full conventions: see `packages/ui/AGENTS.md` (always loaded).
+
+</Scope>
+
+<Steps>
+
+1. **Pick the right folder** by kind:
+   - Visual primitive (Button, Dialog, ...) → `src/components/<name>.tsx`
+   - Hook (`useIsMobile`, ...) → `src/hooks/<name>.ts`
+   - Pure utility (`cn`, formatters) → `src/lib/<name>.ts`
+
+2. **Prefer the shadcn CLI** when the component exists in the registry:
+   ```
+   cd apps/web && pnpm dlx shadcn@latest add <component>
+   ```
+   This writes the file into `packages/ui/src/components/` (per
+   `apps/web/components.json`) and wires the subpath export automatically.
+
+3. **For a hand-written primitive**, mirror the existing pattern in
+   `src/components/button.tsx`:
+   - `import { cva, type VariantProps } from 'class-variance-authority'`
+   - `import { Slot } from '@radix-ui/react-slot'` when polymorphism is needed
+   - `import { cn } from '@workspace/ui/lib/utils'`
+   - Define `const <name>Variants = cva(...)` with `variants` + `defaultVariants`
+   - Type props as `React.ComponentProps<'tag'> & VariantProps<typeof <name>Variants> & { asChild?: boolean }`
+   - Add `data-slot='<name>'` to the root element
+   - Use `const Comp = asChild ? Slot : 'tag'`
+   - `export { <Name>, <name>Variants }` (named exports, matching `button.tsx`)
+
+4. **Mark `'use client'` only when the component** needs browser APIs, React
+   context, hooks, or `next-themes`/`sonner` (see `src/components/sonner.tsx`
+   for the client pattern). Keep primitives server-component-safe by default.
+
+5. **No barrel update needed** — subpath exports use file globs:
+   - `@workspace/ui/components/*` → `./src/components/*.tsx`
+   - `@workspace/ui/hooks/*` → `./src/hooks/*.ts`
+   - `@workspace/ui/lib/*` → `./src/lib/*.ts`
+   Just create the file; the export resolves automatically.
+
+6. **Accessibility**: lean on Radix semantics, keyboard support, focus
+   management, and `aria-*` where Radix doesn't cover it.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.packages.ui` — ESLint with `--max-warnings 0`
+- `nps typecheck.packages.ui` — `tsc --noEmit`
+- `nps build.web` — end-to-end transpile via `next-transpile-modules`
+  (this package has no `build` script of its own)
+- Consume it from `apps/web`: `import { <Name> } from '@workspace/ui/components/<name>'`
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT deep-import via relative paths from `apps/web` (e.g.
+  `../../packages/ui/src/components/button`). Always use the subpath.
+- Do NOT add `'use client'` to primitives that don't need it — it forces the
+  whole subtree into the client bundle.
+- Do NOT pre-abstract a component that has only one consumer. Keep it in
+  `apps/web` until a second package needs it.
+- Do NOT add comments unless the logic is non-obvious (repo convention).
+
+</AntiPatterns>

--- a/.opencode/skills/add-web-test/SKILL.md
+++ b/.opencode/skills/add-web-test/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: add-web-test
+description: Use when adding a Vitest test for apps/web (components, pages, slices, utils). Covers the customRender wrapper (RouterContext + ReduxToolProvider + ThemeProvider), vitest.setup.js global mocks, awaiting async server components before render, and test file placement under src/tests. Trigger keywords: "vitest test", "jsdom", "customRender", "testing library", "test web".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: web
+  stack: vitest,jsdom,testing-library,react19
+---
+
+<Goal>
+
+Add a Vitest + jsdom test for `apps/web` that renders components through the
+project's `customRender` wrapper (so router, Redux, and theme context are all
+present) and correctly handles async server components.
+
+</Goal>
+
+<Scope>
+
+- App: `apps/web`
+- Test location: `src/tests/**/*.test.tsx` (mirror the path of the code under
+  test, e.g. code at `src/app/page.tsx` → test at `src/tests/app/page.test.tsx`)
+- Utilities:
+  - `src/tests/testUtils.tsx` — `customRender` (re-exported as `render`)
+  - `src/tests/vitest.setup.js` — global mocks (`matchMedia`,
+    `IntersectionObserver`, `next/router`)
+- Reference: `src/tests/app/page.test.tsx`.
+- Full conventions: see `apps/web/AGENTS.md` (always loaded).
+
+</Scope>
+
+<Steps>
+
+1. **Place the test** under `src/tests/`, mirroring the source path. Example:
+   - Source: `src/components/MyComponent.tsx`
+   - Test: `src/tests/components/MyComponent.test.tsx`
+
+2. **Import `render` from `../testUtils`** (relative to the test file), NOT
+   from raw `@testing-library/react`. `testUtils.tsx` re-exports
+   `customRender` as `render` and also re-exports `@testing-library/react` and
+   `@testing-library/user-event`:
+   ```tsx
+   import { render, act, waitFor, screen } from '../testUtils';
+   ```
+
+3. **For async server components**, `await` the component before rendering
+   (they return a `Promise<ReactElement>`):
+   ```tsx
+   import MyPage from '../../app/page';
+
+   it('renders', async () => {
+     await act(async () => {
+       render(await MyPage());
+     });
+     await waitFor(() => {
+       expect(screen.getByText(/title/i)).toBeInTheDocument();
+     });
+   });
+   ```
+   See `src/tests/app/page.test.tsx:5-14` for the exact pattern.
+
+4. **For client components** that use Redux, the wrapper already provides
+   `ReduxToolProvider` with the real store. Dispatch via `useAppDispatch` inside
+   the component under test, or pre-seed state by rendering a setup component
+   that dispatches before your assertions.
+
+5. **For router-dependent components**, `testUtils.tsx` injects a mock
+   `NextRouter` via `RouterContext`. Override per-test by passing
+   `{ router: { ...customRouter } }` as the second argument to `render`.
+
+6. **Add global mocks** (browser APIs, `next/router`, etc.) to
+   `src/tests/vitest.setup.js`, NOT per-test. `matchMedia`,
+   `IntersectionObserver`, and `next/router` are already mocked there.
+
+7. Use `@testing-library/jest-dom` matchers (`toBeInTheDocument`, ...) — they
+   are wired up in `vitest.setup.js`.
+
+</Steps>
+
+<Verify>
+
+- `cd apps/web && pnpm test -- path/to/test.test.tsx` — single file
+- `nps test.web` — all web app tests
+- `nps test.watch` — watch mode
+- `nps lint.web` + `nps typecheck.web` — keep the test green with lint/types
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT import `render` from `@testing-library/react` directly — it bypasses
+  the Router/Redux/Theme providers and breaks router/Redux-dependent
+  components. Use `render` from `../testUtils`.
+- Do NOT forget to `await` async server components before `render(...)` —
+  `render(MyPage())` (no `await`) renders a Promise, not the tree.
+- Do NOT add `matchMedia` / `IntersectionObserver` / `next/router` mocks
+  per-test — they belong in `src/tests/vitest.setup.js`.
+- Do NOT put tests outside `src/tests/` — that's the configured glob.
+
+</AntiPatterns>

--- a/.opencode/skills/edit-middleware/SKILL.md
+++ b/.opencode/skills/edit-middleware/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: edit-middleware
+description: Use when adding or editing Next.js middleware in apps/web (rate limiting, auth, proxy/rewrite). Covers the chain() composition in proxy.ts, the NextProxyFactory pattern, ratelimit.ts, the config matcher, and registering factories in top-to-bottom execution order. Trigger keywords: "middleware", "NextProxy", "chain", "proxy.ts", "rate limit", "ratelimit".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: web
+  stack: nextjs-16,middleware,next-server
+---
+
+<Goal>
+
+Add or modify a middleware in `apps/web` and wire it into the composed
+`chain([...])` in `proxy.ts`, preserving the `(proxy: NextProxy) => NextProxy`
+factory convention and top-to-bottom execution order.
+
+</Goal>
+
+<Scope>
+
+- App: `apps/web`
+- Files:
+  - `src/middlewares/<name>.ts` — new middleware factory (create this)
+  - `src/middlewares/index.ts` — barrel (`export * from './<name>'`)
+  - `src/proxy.ts` — `chain([...])` registration + `config` matcher
+- Reference: `src/middlewares/ratelimit.ts` (the canonical factory).
+- Full conventions: see `apps/web/AGENTS.md` (always loaded).
+
+</Scope>
+
+<Steps>
+
+1. **Create the middleware factory** in `src/middlewares/<name>.ts`. A factory
+   is `(proxy: NextProxy) => NextProxy` — it wraps the next middleware and
+   returns a new one. Mirror `ratelimit.ts:137-179`:
+   ```ts
+   import { type NextFetchEvent, type NextProxy, type NextRequest, NextResponse } from 'next/server';
+
+   export function <name>(proxy: NextProxy, /* options */): NextProxy {
+     return async (request: NextRequest, event: NextFetchEvent) => {
+       // pre-processing
+       const response = await proxy(request, event); // call next in chain
+       // post-processing (e.g. set headers)
+       return response;
+     };
+   }
+   ```
+2. **Export from the barrel** in `src/middlewares/index.ts`:
+   ```ts
+   export * from './<name>';
+   ```
+3. **Register in `proxy.ts`** `chain([...])` array. Order is top-to-bottom —
+   the first factory is the outermost wrapper (runs first on the way in, last
+   on the way out):
+   ```ts
+   import { ratelimit, <name> } from './middlewares';
+
+   export default chain([
+     ratelimit,
+     <name>,
+     // ...Add middleware here (executed in order from top to bottom)
+   ]);
+   ```
+   `ratelimit` is commented out by default — uncomment when you actually want
+   it.
+4. **The `config.matcher`** in `proxy.ts:13-27` already excludes
+   `_next/static`, `_next/image`, favicons, etc. Extend it only if your
+   middleware needs a different match set.
+5. **Import shared constants from `@workspace/constants`** (e.g.
+   `rateLimitConfigs`, `RateLimitConfig`) — never duplicate them locally.
+   `ratelimit.ts:3` shows the import.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.web` — ESLint `--max-warnings 0`
+- `nps typecheck.web` — `tsc --noEmit`
+- `nps build.web` — `next build`
+- `nps dev.web` — exercise the route path in the browser; check headers (e.g.
+  `X-RateLimit-Remaining`) and 429 behavior if rate-limiting.
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT write a raw `NextMiddleware` that ignores `chain()` — every
+  middleware must be a `(proxy: NextProxy) => NextProxy` factory so composition
+  works.
+- Do NOT forget to `await proxy(request, event)` inside the factory — that's
+  how the chain advances. Skipping it short-circuits downstream middleware.
+- Do NOT duplicate `rateLimitConfigs` / `RateLimitConfig` in `apps/web` —
+  import from `@workspace/constants`.
+- Do NOT edit `config.matcher` casually — it already excludes static assets;
+  wrong exclusions can break the app.
+
+</AntiPatterns>

--- a/.opencode/skills/nextjs-rsc-streaming/SKILL.md
+++ b/.opencode/skills/nextjs-rsc-streaming/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: nextjs-rsc-streaming
+description: Use when implementing React Server Component streaming in apps/web (Next.js 16 + React 19) — page-level Promise kickoff, Suspense boundaries with colocated *Skeleton fallbacks, use() in client components, redirect()/notFound() streamed through boundaries, and the loading.tsx-removal + top-loader pattern. FORESIGHT recipe: the starter does not currently use this; adopt when a page fetches data and you want progressive streaming. Trigger keywords: "RSC streaming", "Suspense", "use()", "Promise.all", "loading.tsx", "streaming", "React 19".
+license: MIT
+compatibility: opencode
+metadata:
+  category: foresight
+  package: web
+  stack: nextjs-16,react-19,suspense,rsc-streaming
+---
+
+<Goal>
+
+Stream a Next.js 16 page progressively: render the static frame immediately,
+kick off data fetches as un-awaited Promises at the page level, and resolve
+each inside its own `<Suspense>` boundary so the user sees content as soon as
+each dependency settles — instead of waiting for the slowest request before
+first paint.
+
+</Goal>
+
+<Context>
+
+This skill is a **foresight recipe**. The starter (`apps/web`) does not
+currently use RSC streaming — its data layer is client-side Redux Toolkit.
+Adopt this pattern when a page needs to fetch server-side data (e.g. from an
+API) and you want progressive rendering. It is fully compatible with the
+existing Redux/Provider setup — streaming lives in server components, Redux
+lives in client components.
+
+The pattern is translated from a production Next 16 + React 19 codebase where
+it is codified in `apps/web/AGENTS.md`.
+
+</Context>
+
+<Scope>
+
+- App: `apps/web`, under `src/app/`
+- Files touched: `page.tsx`, `layout.tsx`, route-local `components/*.tsx`,
+  colocated `*Skeleton.tsx` fallbacks
+- Server-component data fetches (Server Actions or async fetchers) live in
+  `src/lib/` or `app/<route>/data.ts` — adapt to whatever data layer you add.
+
+</Scope>
+
+<Steps>
+
+1. **At the page level, kick off fetches as Promises WITHOUT awaiting them.**
+   Await only `params`, `searchParams`, and cheap per-request helpers
+   (e.g. `getTranslations` if you add i18n):
+   ```tsx
+   export default async function Page({ params }: PageProps<{ slug: string }>) {
+     const { slug } = await params;
+     const dataPromise = loadData(slug);      // NOT awaited
+     const metaPromise = loadMeta(slug);      // NOT awaited
+     return (
+       <PageContainer>
+         <Suspense fallback={<DataSkeleton />}>
+           <DataSection dataPromise={dataPromise} />
+         </Suspense>
+         <Suspense fallback={<MetaSkeleton />}>
+           <MetaSection metaPromise={metaPromise} />
+         </Suspense>
+       </PageContainer>
+     );
+   }
+   ```
+
+2. **The consuming section (server component) awaits the promise INSIDE the
+   boundary** — this is what makes it stream:
+   ```tsx
+   export async function DataSection({ dataPromise }: { dataPromise: Promise<Data> }) {
+     const data = await dataPromise;
+     if (!data) notFound();                   // streams through THIS boundary
+     return <...>;
+   }
+   ```
+
+3. **One `<Suspense>` per independent data dependency**, each with a colocated
+   `*Skeleton` fallback. Keep static UI (card frames, headers, descriptions)
+   OUTSIDE the boundary so it paints immediately; only the data-dependent body
+   streams.
+
+4. **Client components unwrap the SAME shared promise with React 19 `use()`**,
+   inside their own `<Suspense>`:
+   ```tsx
+   'use client';
+   import { use } from 'react';
+
+   export function ClientSection({ promise }: { promise: Promise<X> }) {
+     const x = use(promise);                  // suspends until resolved
+     return <...>;
+   }
+   ```
+   Wrap the consumer in `<Suspense fallback={<...Skeleton/>}>` at the call
+   site. Never call `use()` conditionally — it must be at the top of the
+   component.
+
+5. **`redirect()` and `notFound()` fire INSIDE the consuming section**, not at
+   the page level. This lets them stream through that boundary without aborting
+   sibling boundaries.
+
+6. **Chain promises to keep first paint fast.** Slow dependent fetches can be
+   `.then()`-chained (still without page-level await):
+   ```tsx
+   const sectionsPromise = loadSections(slug);
+   const lecturesPromise = sectionsPromise.then((s) => loadLectures(slug, s));
+   ```
+   Only the boundary that needs `lectures` waits on the chain.
+
+7. **Drop `loading.tsx` and use a top loader instead.** Per-route
+   `loading.tsx` files flash a full-page skeleton on every navigation. Replace
+   with `nextjs-toploader` (nprogress-style bar) so the previous page stays on
+   screen while the next RSC payload streams in:
+   ```tsx
+   // app/layout.tsx
+   import NextTopLoader from 'nextjs-toploader';
+   // ...
+   <NextTopLoader />   // alongside <Toaster />
+   ```
+   Do NOT add `loading.tsx` files anywhere once you adopt this pattern.
+
+8. **Session/auth streaming (only if you add auth).** Wrap the session lookup
+   in React `cache()` for per-request dedupe, and split into a redirecting
+   accessor (`requireSession()` that throws `redirect()`) and a non-redirecting
+   one (`getSession()` that resolves to `null`). Layouts create the promise
+   without awaiting and render a guard inside `<Suspense fallback={null}>` so
+   the shell paints instantly and `redirect()` is delivered through the stream.
+   (The starter has no auth today — skip until needed.)
+
+9. **Graceful degradation.** Failed fetches should resolve to `null`/empty via
+   a helper (e.g. `unwrapOrNull(promise)`) so one endpoint failure doesn't
+   break the whole page — the affected boundary just renders its empty state.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.web` + `nps typecheck.web`
+- `nps build.web`
+- `nps dev.web` — throttle the network in DevTools and confirm the static
+  frame paints first, then each section fills in as its promise resolves
+  (no full-page skeleton flash).
+- Confirm `redirect()`/`notFound()` stream through the correct boundary
+  without aborting siblings.
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT `await` data fetches at the page level — that blocks the whole page
+  on the slowest request and defeats streaming.
+- Do NOT put `notFound()`/`redirect()` at the page level — they belong inside
+  the consuming section so they stream through that boundary.
+- Do NOT add `loading.tsx` files alongside this pattern — they reintroduce the
+  full-page skeleton flash. Use a top loader.
+- Do NOT call `use()` conditionally or in loops — it's a hook-like primitive;
+  call it unconditionally at the top of the client component.
+- Do NOT create a `<Suspense>` without a colocated `*Skeleton` fallback —
+  `fallback={null}` is acceptable only for invisible guards (e.g. session
+  guards), not for user-visible content.
+
+</AntiPatterns>

--- a/.opencode/skills/nextjs-server-action/SKILL.md
+++ b/.opencode/skills/nextjs-server-action/SKILL.md
@@ -1,0 +1,496 @@
+---
+name: nextjs-server-action
+description: Use when implementing a Next.js Server Action in apps/web with React 19 useActionState and Sonner toast feedback. Covers the two-tier 'use server' architecture (route action.ts + src/lib/api SDK), the ActionResult<T> shape, inline toast wrapper with stable id + mutation lock, optimistic-on-success derived render, direct-await pattern for non-form actions, revalidateTag(tag, 'max') cache invalidation, and the notice/log error split. FORESIGHT recipe: the starter does not currently use server actions; adopt when a form or button needs to mutate server state with progressive feedback. Trigger keywords: "server action", "use server", "useActionState", "ActionResult", "Sonner", "toast", "revalidateTag", "form mutation", "logout action".
+license: MIT
+compatibility: opencode
+metadata:
+  category: foresight
+  package: web
+  stack: nextjs-16,react-19,server-actions,sonner,use-action-state
+---
+
+<Goal>
+
+Add a Next.js Server Action that mutates server state from a client form (or
+button/menu), surface progressive feedback via Sonner toasts, and invalidate the
+relevant cache — using the proven, repo-accurate pattern below.
+
+</Goal>
+
+<Context>
+
+This skill is a **foresight recipe**. The starter (`apps/web`) does not
+currently use Server Actions — its state is client-side Redux Toolkit, and
+`rg "use server"` returns zero hits. Adopt this pattern when a form or button
+needs to submit data to the server (e.g. settings save, logout) with
+progressive, toast-based feedback.
+
+The Sonner toaster is already mounted in `app/layout.tsx` via `<Toaster />`
+(`@workspace/ui/components/sonner`), so no new provider is needed.
+
+This recipe is adapted from a production Next 16 + React 19 codebase. The
+patterns below are proven, not theoretical.
+
+</Context>
+
+<Architecture>
+
+Two `'use server'` tiers — this is the backbone of the pattern:
+
+<Tier1>
+
+**Route-local action** — `app/<route>/action.ts` (singular) or
+`app/<route>/actions.ts` (plural), placed **next to `page.tsx`**, NOT under
+`components/`. Thin entry point invoked from the client:
+- validates `formData` by hand
+- calls into Tier 2 (the SDK)
+- calls `revalidateTag(tag, 'max')` on success
+- returns `ActionResult<T>`
+
+</Tier1>
+
+<Tier2>
+
+**Server-only SDK** — `src/lib/api/**/*.ts`, the whole module marked
+`'use server'`. The backend boundary. Wraps a fetch client (or your own API
+client). Also called directly from server components for reads.
+
+Why `'use server'` on the whole module (instead of the `server-only` package)?
+Because the SDK needs `cookies()` / `headers()` / `revalidateTag()` —
+`'use server'` is the boundary marker that makes none of it importable into a
+client component. That's a hard boundary, enforced by the compiler.
+
+</Tier2>
+
+</Architecture>
+
+<ResultType>
+
+Define a single shared generic union in `src/lib/api/types.ts`. **No `ok`
+field, no `fieldErrors`** — errors are one client-safe `message` + `code`:
+
+```ts
+// src/lib/api/types.ts
+import type { ErrorCode } from '@workspace/constants';
+
+export type ActionSuccessResult<T> = {
+  success: true;
+  isError: false;
+  data: T;
+};
+
+export type ActionErrorResult = {
+  success: false;
+  isError: true;
+  code: ErrorCode | 'UNKNOWN';
+  message: string; // client-safe — from ErrorMessage.notice / NodeErrorMessage.notice
+};
+
+export type ActionResult<T> = ActionSuccessResult<T> | ActionErrorResult;
+```
+
+The route action's `prev` parameter is typed **`null`** and is always invoked
+with `null` from the client (not a union with the result):
+
+```ts
+// app/<route>/actions.ts
+'use server';
+
+export async function saveThing(
+  _: null,
+  formData: FormData,
+): Promise<ActionResult<Thing>> { /* ... */ }
+```
+
+</ResultType>
+
+<ErrorNormalization>
+
+Enforce the "don't leak `log` to the client" rule structurally, not just by
+convention. Put a normalizer in `src/lib/api/utils/toActionErrorResult.ts`:
+
+```ts
+import type { ActionErrorResult } from '../types';
+import { NodeErrorMessage, type ErrorCode } from '@workspace/constants';
+
+export function toActionErrorResult(e: unknown): ActionErrorResult {
+  const base = { success: false, isError: true } as const;
+  // If you adopt a custom API client with notice/log split (like SDKError),
+  // branch on it here and return e.noticeMessage — keep e.logMessage server-side.
+  if (e instanceof Error) {
+    return { ...base, code: 'UNKNOWN' as const, message: NodeErrorMessage.NodeError.notice };
+  }
+  return { ...base, code: 'UNKNOWN' as const, message: NodeErrorMessage.UnknownError.notice };
+}
+```
+
+Rule: **the action/SDK returns `ErrorMessage.notice` / `NodeErrorMessage.notice`
+to the client; `.log` stays server-side** (pass it to your logger only). This is
+the structural enforcement — a future custom error class with separate
+`noticeMessage` / `logMessage` fields slots in naturally.
+
+</ErrorNormalization>
+
+<Scope>
+
+- App: `apps/web`
+- Tier 1: `app/<route>/action.ts` or `app/<route>/actions.ts`
+- Tier 2: `src/lib/api/**/*.ts` (`types.ts`, per-domain modules,
+  `utils/toActionErrorResult.ts`, `utils/cacheTags.ts`, `utils/revalidate.ts`)
+- Client consumers: `'use client'` components under `app/<route>/components/`
+- Toasts: `import { toast } from 'sonner'` (transitive via `@workspace/ui`)
+
+</Scope>
+
+<Steps>
+
+### 1. Write the shared result types + normalizer
+
+Create `src/lib/api/types.ts` (see `<ResultType>`) and
+`src/lib/api/utils/toActionErrorResult.ts` (see `<ErrorNormalization>`). Add
+barrels (`src/lib/api/index.ts`, `src/lib/api/utils/index.ts`) as you add
+modules.
+
+### 2. Write the Tier 2 SDK module
+
+`src/lib/api/<domain>.ts`, marked `'use server'` at the top. Each function
+resolves the session (when you add auth), calls the backend, returns
+`ActionResult<T>`, and normalizes throws via `toActionErrorResult`:
+
+```ts
+'use server';
+
+import type { ActionResult } from './types';
+import { toActionErrorResult } from './utils';
+
+export async function getThing(id: string): Promise<ActionResult<Thing>> {
+  try {
+    const res = await fetch(`${process.env.API_URL}/things/${id}`, {
+      cache: 'force-cache',
+      next: { tags: [thingTag(id)], revalidate: 0 },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as Thing;
+    return { success: true, isError: false, data };
+  } catch (e: unknown) {
+    return toActionErrorResult(e);
+  }
+}
+
+export async function updateThing(id: string, input: Partial<Thing>): Promise<ActionResult<Thing>> {
+  try {
+    const res = await fetch(`${process.env.API_URL}/things/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as Thing;
+    return { success: true, isError: false, data };
+  } catch (e: unknown) {
+    return toActionErrorResult(e);
+  }
+}
+```
+
+When you add auth, gate mutations with a `requireSession` helper that returns
+`{ success: false, isError: true, code: ErrorCode.Unauthorized, message: ErrorMessage[ErrorCode.Unauthorized].notice }`.
+
+### 3. Centralize cache tags + revalidate helpers
+
+`src/lib/api/utils/cacheTags.ts` — `as const` tag builders:
+
+```ts
+export const thingTag = (id: string) => `Thing:${id}` as const;
+```
+
+`src/lib/api/utils/revalidate.ts` — `'use server'`; one helper per tag, using
+the Next 16 `'max'` revalidateType:
+
+```ts
+'use server';
+import { revalidateTag } from 'next/cache';
+import { thingTag } from './cacheTags';
+
+export async function revalidateThing(id: string) {
+  revalidateTag(thingTag(id), 'max');
+}
+```
+
+**Use `revalidateTag(tag, 'max')` only — not `revalidatePath`.** Reads opt
+into caching via `next: { tags: [...], revalidate: 0 }` on the fetch call.
+
+### 4. Write the Tier 1 route action
+
+`app/<route>/actions.ts`, `'use server'`. Thin: validate `formData` by hand,
+call Tier 2, `revalidateTag` on success, return `ActionResult<T>`:
+
+```ts
+'use server';
+
+import { updateThing, revalidateThing } from '@/lib/api';
+import type { ActionResult, Thing } from '@/lib/api/types';
+import { NodeErrorMessage } from '@workspace/constants';
+
+function validateName(v: FormDataEntryValue | null): { isError: boolean; message: string } {
+  if (typeof v !== 'string' || !v.trim()) return { isError: true, message: 'Name is required.' };
+  return { isError: false, message: '' };
+}
+
+export async function saveThing(
+  _: null,
+  formData: FormData,
+): Promise<ActionResult<Thing>> {
+  const id = String(formData.get('id') ?? '');
+  const nameCheck = validateName(formData.get('name'));
+  if (nameCheck.isError) {
+    return { success: false, isError: true, code: 'UNKNOWN', message: nameCheck.message };
+  }
+  const result = await updateThing(id, { name: nameCheck.message === '' ? String(formData.get('name')) : '' });
+  if (result.success) {
+    await revalidateThing(id);
+  }
+  return result;
+}
+```
+
+Hand-rolled validation is the convention here. `zod` is available via
+`@workspace/ui` but is **not** used for action validation in the reference
+codebase — keep it hand-rolled unless a form has complex rules.
+
+**Do NOT call `redirect()` inside the action.** Post-action navigation is
+client-side `router.push(...)` in the consumer (see step 6).
+
+### 5. Client consumer — form action via `useActionState` + inline toast wrapper
+
+This is the core pattern. The function passed to `useActionState` is **a
+wrapper you write**, not the action itself. Toasts fire **inline inside the
+wrapper**, NOT in a `useEffect`. Pending comes from `useActionState`'s third
+element — **do not use `useTransition`**. Guard double-submit with a `useRef`
+mutation lock:
+
+```tsx
+'use client';
+import { useActionState, useRef, useState, use } from 'react';
+import { toast } from 'sonner';
+import { saveThing } from '../actions';
+import type { ActionResult, Thing } from '@/lib/api/types';
+
+type State = Awaited<ReturnType<typeof saveThing> | null>;
+
+export function ThingForm({ thingPromise }: { thingPromise: Promise<Thing> }) {
+  const baseThing = use(thingPromise); // RSC → client Promise hand-off for the read path
+  const [lastMutation, setLastMutation] = useState<'save' | null>(null);
+  const mutationLockRef = useRef(false);
+  const [isMutating, setIsMutating] = useState(false);
+
+  const [saveState, saveAction, isSavePending] = useActionState<State, FormData>(
+    async (_prev, formData) => {
+      if (mutationLockRef.current) return _prev;            // 1. mutation lock
+      mutationLockRef.current = true;
+      setIsMutating(true);
+      try {
+        toast.loading('Saving…', { id: 'thing-save' });     // 2. loading toast w/ stable id
+        formData.append('id', baseThing.id);               // 3. enrich formData
+        const result = await saveThing(null, formData);    // 4. call action w/ null prev
+        if (!result.success) {                             // 5. branch on success
+          toast.error('Save failed', { id: 'thing-save', description: result.message });
+        } else {
+          toast.success('Saved', { id: 'thing-save' });    //    same id replaces loading
+          setLastMutation('save');
+        }
+        return result;                                     // 6. store as state
+      } finally {
+        mutationLockRef.current = false;
+        setIsMutating(false);
+      }
+    },
+    null,
+  );
+
+  // Optimistic-on-success: show the just-saved value immediately while
+  // revalidateTag refreshes the cache in the background.
+  const effectiveThing =
+    lastMutation === 'save' && saveState?.success ? saveState.data : baseThing;
+
+  const disabled = isMutating || isSavePending;
+
+  return (
+    <form action={saveAction}>
+      <input name='name' defaultValue={effectiveThing.name} disabled={disabled} />
+      <button type='submit' disabled={disabled}>
+        {isSavePending ? 'Saving…' : 'Save'}
+      </button>
+    </form>
+  );
+}
+```
+
+Key rules:
+- **Toasts fire inside the wrapper**, before/after `await action(...)`, never
+  in a `useEffect`.
+- The stable string `id` (`'thing-save'`) lets `toast.loading` →
+  `toast.success`/`toast.error` replace the same toast in place.
+- React to the resolved state by **derived render** (the `effectiveThing`
+  line), NOT `useEffect`. This is optimistic-on-success: the user sees the new
+  value immediately while `revalidateTag` refreshes the cache.
+- The read path uses the RSC→client Promise hand-off: the server `page.tsx`
+  builds `thingPromise = getThing(id)` and passes it to the client component,
+  which `use()`s it. The write path is the route action.
+
+### 6. Client consumer — non-form action via direct await
+
+For actions triggered from a button/menu (logout, icon delete) — **no `<form>`**
+and **no `useActionState`**. Direct `await action()` in an async handler with
+`useState` pending and client-side `router.push`:
+
+```tsx
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { logoutAction } from './action';
+
+export function LogoutMenuItem() {
+  const [isPending, setIsPending] = useState(false);
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      toast.loading('Logging out…', { id: 'logout' });
+      const result = await logoutAction();          // no formData, no prev
+      if (result.isError) {                         // note: isError flag, not !success
+        toast.error('Logout failed', { id: 'logout', description: result.message });
+        return;
+      }
+      toast.success('Logged out', { id: 'logout' });
+      router.push('/login');                        // client-side nav, no redirect()
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return <button onClick={handleLogout} disabled={isPending}>Log out</button>;
+}
+```
+
+### 7. Confirm-dialog-as-form-host (optional, for destructive mutations)
+
+When a mutation needs confirmation, render `<form action={action}>` **inside a
+Radix Dialog** (via `@workspace/ui/components/dialog`). Disable Escape /
+outside-click while pending so the dialog can't be dismissed mid-submit:
+
+```tsx
+'use client';
+import type { ComponentProps } from 'react';
+import { Dialog, DialogContent, DialogFooter, DialogTitle } from '@workspace/ui/components/dialog';
+import { Button } from '@workspace/ui/components/button';
+
+export function ConfirmDeleteDialog({
+  action,
+  isPending,
+  open,
+  onOpenChange,
+}: {
+  action: ComponentProps<'form'>['action'];
+  isPending: boolean;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={!isPending}
+        onEscapeKeyDown={(e) => { if (isPending) e.preventDefault(); }}
+        onPointerDownOutside={(e) => { if (isPending) e.preventDefault(); }}
+      >
+        <DialogTitle>Delete this?</DialogTitle>
+        <DialogFooter>
+          <form action={action}>
+            <Button type='submit' variant='destructive' disabled={isPending}>
+              {isPending ? 'Deleting…' : 'Delete'}
+            </Button>
+          </form>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+The `useActionState` action reference is passed down as
+`ComponentProps<'form'>['action']` and wired onto the inner `<form>` here.
+
+### 8. Inline field errors (recommended, not always needed)
+
+The reference codebase has no text-input forms (wallet addresses come from
+wallet adapters), so it renders only a `text-destructive` line for fetch
+failures:
+
+```tsx
+{!fetchResult.success && (
+  <div className='text-xs text-destructive'>{fetchResult.message}</div>
+)}
+```
+
+For forms with **user-typed inputs**, adding `aria-describedby` / `aria-invalid`
++ `role='alert'` is a recommended a11y improvement — but it is NOT part of the
+proven baseline. Add it only if your form actually has typed fields.
+
+</Steps>
+
+<Verify>
+
+- `nps lint.web` + `nps typecheck.web`
+- `nps build.web`
+- `nps test.web` — mock the action module and assert the wrapper flow:
+  ```tsx
+  vi.mock('../actions', async () => {
+    const actual = await vi.importActual<typeof import('../actions')>();
+    return {
+      ...actual,
+      saveThing: vi.fn(async (_: null, fd: FormData) => {
+        // assert the wrapper enriched formData
+        expect(fd.get('id')).toBe('thing-1');
+        return { success: true, isError: false, data: { id: 'thing-1', name: 'new' } };
+      }),
+    };
+  });
+  // then: act(() => saveButton.click()) and assert the rendered value updates
+  ```
+  See the `add-web-test` skill for `customRender` (Router + Redux + Theme
+  providers are already wired).
+- `nps dev.web` — submit the form and confirm: loading toast → success/error
+  toast (same id, replaces in place), pending disables the button, the
+  optimistic value shows immediately, and `revalidateTag` refreshes in the
+  background.
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT return `{ ok: true } | { ok: false; fieldErrors }` — the canonical
+  shape is `ActionResult<T>` with `success` / `isError` / `data?` / `code` /
+  `message`. No per-field errors.
+- Do NOT fire toasts in a `useEffect` reacting to `state` — fire them **inline
+  inside the `useActionState` wrapper** (before/after `await action(...)`).
+- Do NOT use `useTransition` for pending — use `useActionState`'s third element
+  `isPending` (+ the `useRef` mutation lock).
+- Do NOT call `redirect()` inside the action — post-action navigation is
+  client-side `router.push(...)`.
+- Do NOT use `revalidatePath` — use `revalidateTag(tag, 'max')` via centralized
+  `cacheTags.ts` + `revalidate*.ts` helpers.
+- Do NOT leak `ErrorMessage.log` / `NodeErrorMessage.log` to the client —
+  return only `.notice`. Enforce it in `toActionErrorResult`.
+- Do NOT put real backend work in the route action — delegate to the Tier 2 SDK
+  in `src/lib/api/**` (also `'use server'`).
+- Do NOT reach for `useFormState` — it's deprecated in React 19; use
+  `useActionState`.
+- Do NOT reach for zod / react-hook-form unless the form has complex rules —
+  hand-rolled validation is the convention.
+- Do NOT put the route action under `components/` — it sits next to `page.tsx`
+  as `action.ts` / `actions.ts`.
+
+</AntiPatterns>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,13 @@ full options.
 - **Lint**: `nps lint` (all), `nps lint.web`, `nps lint.packages` (or
   `nps lint.packages.ui`)
 - **Format**: `nps format` (all), `nps format.web`, `nps format.packages`
+- **Typecheck**: `nps typecheck` (all), `nps typecheck.web`,
+  `nps typecheck.packages` (or `nps typecheck.packages.ui`)
 - **Test**: `nps test` (all), `nps test.web` (web app tests), `nps test.watch`
+- **Dev**: `nps dev` (all), `nps dev.web`
 - **Single test**: `cd apps/web && pnpm test -- path/to/test.test.tsx`
 
-## App-specific Guidelines
+## App- and Package-specific Guidelines
 
-For Web app specific guidelines and testing locations, see @apps/web/AGENTS.md
+For app- and package-specific guidelines, see @apps/web/AGENTS.md and
+@packages/*/AGENTS.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-This is a monorepo with TypeScript, Turbo, and Yarn workspaces.
+This is a monorepo with TypeScript, Turbo, and pnpm workspaces.
 
 ## General Rules
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ configurations.
 - **Code Quality**: ESLint, Prettier, and Husky for consistent code standards
 - **Testing**: Vitest setup for unit and integration tests
 - **Git Workflow**: Commitizen and Commitlint for conventional commits
+- **AI Agent Skills**: opencode on-demand skills (`.opencode/skills/`) with
+  per-package `AGENTS.md` auto-loaded as instructions
 - **Best Practices**: Optimized configurations and development guidelines
 
 ## 🛠 Tech Stack
@@ -32,8 +34,11 @@ configurations.
 - **Monorepo**: [Turborepo](https://turbo.build) with pnpm Workspaces
 - **Runtime**: Node.js 24+
 - **Language**: TypeScript 5+
-- **Framework**: Next.js with App Router
+- **Framework**: [Next.js 16](https://nextjs.org) (App Router) + [React 19](https://react.dev)
 - **UI Library**: React with Shadcn/ui components
+- **State**: Redux Toolkit + react-redux
+- **Theming**: next-themes
+- **Toasts**: sonner (via `@workspace/ui`)
 - **Styling**: Tailwind CSS and PostCSS
 - **Testing**: Vitest
 - **Code Quality**: ESLint, Prettier
@@ -54,8 +59,9 @@ turborepo-starter/
 │   ├── ui/                # Shared UI components (Shadcn/ui)
 │   └── vitest/            # Shared Vitest configuration
 ├── docs/
-│   ├── github-actions/    #
-│   └── instructions/      # Development guidelines for AI agents
+│   ├── github-actions/    # GitHub Actions workflow documentation
+│   └── instructions/      # GitHub-workflow guidelines for AI agents (GENERAL/ISSUE/TASK/REVIEW)
+├── .opencode/             # opencode skills and agent config
 ├── .github/               # GitHub Actions workflows
 └── .husky/                # Git hooks configuration
 ```

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -2,6 +2,69 @@
 
 For general rules and code style guidelines, see @AGENTS.md.
 
+### Stack
+
+- **Next.js 16** App Router + **React 19** + **Redux Toolkit** + **react-redux**.
+- `next-themes` for theming, `sonner` for toasts (via `@workspace/ui`).
+- UI primitives from `@workspace/ui/components/*`; shared types from
+  `@workspace/types/web`.
+
+### Layout
+
+```
+src/
+  app/
+    layout.tsx              # root layout (async, LayoutProps from @workspace/types/web)
+    page.tsx                # root page (async server component)
+    components/             # route-local components (Header, Section, ...)
+    (global-not-found)/     # 404 route group
+      index.tsx             # GlobalNotFoundContent (server component)
+      components/
+  components/
+    Providers/              # client providers (ReduxTool, NextTheme) — 'use client'
+  store/
+    index.ts                # configureStore + typed hooks (useAppDispatch/useAppSelector)
+    slices/                 # createSlice reducers (default-exported)
+  middlewares/
+    index.ts                # barrel
+    ratelimit.ts            # ratelimit() NextProxy wrapper (uses @workspace/constants)
+  proxy.ts                  # chain() + config matcher + default export
+  tests/                    # Vitest + jsdom (see Testing below)
+  types/                    # app-local types (cross-package types go in @workspace/types)
+```
+
+### Conventions
+
+- **Server Components by default.** Mark `'use client'` only for components
+  that need browser APIs, hooks, context, or providers. See
+  `components/Providers/*.tsx` for the pattern.
+- Page/layout props come from `@workspace/types/web` (`PageProps`,
+  `LayoutProps`). `params` and `searchParams` are `Promise<...>` — always
+  `await` them in server components.
+- Import UI via subpaths: `@workspace/ui/components/<name>`,
+  `@workspace/ui/lib/utils` (for `cn`), `@workspace/ui/hooks/<name>`. Never
+  deep-import via relative paths.
+- **Redux Toolkit**: create slices in `store/slices/<name>.ts` with
+  `createSlice`, default-export the reducer, named-export the actions. Register
+  the reducer in `store/index.ts`. Use the typed hooks
+  `useAppDispatch` / `useAppSelector` from `@/store` — never raw
+  `useDispatch`/`useSelector`.
+- **Providers**: wrap the app in `ReduxToolProvider` then `ThemeProvider`
+  (see `app/layout.tsx`). `ThemeProvider` dynamically imports
+  `next-themes`' `ThemeProvider` with `ssr: true`.
+- **Middleware**: compose with `chain([...factories])` in `proxy.ts`. Each
+  factory is `(proxy: NextProxy) => NextProxy`. Add new middleware in
+  `middlewares/`, export from `middlewares/index.ts`, then register in the
+  `chain([...])` array (top-to-bottom execution order). `ratelimit` is
+  available but commented out by default.
+- **404**: the `(global-not-found)` route group renders `GlobalNotFoundContent`.
+  Do not add a top-level `not-found.tsx`; extend this group instead.
+- Keep route-specific components in `app/components/` or
+  `app/<route>/components/`. Promote to `@workspace/ui` only when a second
+  consumer appears.
+- Import shared constants from `@workspace/constants` (e.g.
+  `rateLimitConfigs`, `RateLimitConfig`); never duplicate them locally.
+
 ### Testing
 
 Tests are located in `src/tests/**/*.test.tsx` using Vitest + jsdom.
@@ -11,3 +74,13 @@ Run tests with:
 - `nps test.web` - Run all web app tests
 - `nps test.watch` - Watch mode
 - `cd apps/web && pnpm test -- path/to/test.test.tsx` - Single test file
+
+Test utilities:
+
+- `src/tests/testUtils.tsx` exports `customRender` (re-exported as `render`)
+  that wraps components in `RouterContext` + `ReduxToolProvider` +
+  `ThemeProvider`. Use it instead of raw `@testing-library/react` `render`.
+- `src/tests/vitest.setup.js` mocks `matchMedia`, `IntersectionObserver`, and
+  `next/router`. Add global mocks here.
+- Server components are async — `await` the component before rendering:
+  `render(await RootPage())`, wrapped in `act`/`waitFor` as needed.

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "instructions": ["docs/instructions/*.txt", "apps/**/AGENTS.md"],
+  "instructions": [
+    "docs/instructions/**/*.md",
+    "apps/**/AGENTS.md",
+    "packages/**/AGENTS.md"
+  ],
   "permission": {
     "edit": "ask",
     "bash": {

--- a/packages/constants/AGENTS.md
+++ b/packages/constants/AGENTS.md
@@ -1,0 +1,47 @@
+## Constants Package Guidelines
+
+For general rules and build commands, see @AGENTS.md.
+
+### Stack
+
+- Runtime constants only. **No React, no Next.js, no framework deps.**
+- Built with `tsup`; consumed by `apps/web` (and future packages).
+
+### Layout
+
+```
+src/
+  errors/
+    code.ts        # ErrorCode enum (numeric, grouped by domain)
+    message.ts     # ErrorMessage map + NodeErrorMessage map
+    index.ts       # barrel
+  ratelimitConfigs.ts
+  index.ts         # root barrel
+```
+
+### Conventions
+
+- **Every `ErrorCode` must be paired with an `ErrorMessage`** in
+  `ErrorMessage: Record<ErrorCode, ErrorMessage>`. An orphan code or message is
+  a bug.
+- `ErrorMessage` shape: `{ log: string; notice: string } as const`.
+  - `log` — diagnostic text for server logs (detailed, implementation-facing).
+  - `notice` — user-safe text shown in the UI (generic, no internals).
+- `ErrorCode` is a numeric `enum`. **Never renumber existing codes**; append
+  new ones at the end of their domain group. Group codes by domain with a
+  comment header.
+- `NodeErrorMessage` holds non-`ErrorCode` runtime errors
+  (`'NodeError' | 'UnknownError'`); keep it separate from `ErrorMessage`.
+- `rateLimitConfigs` is `as const` with named tiers
+  (`strict` / `normal` / `loose` / `api`). Each entry matches
+  `RateLimitConfig { windowMs, maxRequests, skipSuccessfulRequests?, skipFailedRequests? }`.
+- Use `as const` for narrow literal types everywhere applicable.
+- Export through the nearest barrel (`errors/index.ts`, then `src/index.ts`).
+  Import from `@workspace/constants` (the root), not deep paths.
+- Don't duplicate these constants in `apps/web`; import them.
+
+### Build & verify
+
+- `nps lint.packages.constants`
+- `nps typecheck.packages.constants`
+- `nps build.packages.constants`

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -1,0 +1,44 @@
+## Types Package Guidelines
+
+For general rules and build commands, see @AGENTS.md.
+
+### Stack
+
+- **Type-only package.** No runtime values, no validation, no React/Next code.
+- Built with `tsc` (emits declaration + JS to `dist/`). Ignore `dist/` when
+  editing — it is build output.
+
+### Layout
+
+```
+src/
+  web/
+    index.ts    # barrel
+    page.ts     # PageProps, SearchParams
+    layout.ts   # LayoutProps, Params, SingleParam, DinamicParams
+```
+
+### Exports (keep in sync with package.json `exports`)
+
+- `@workspace/types/web` → `./src/web/*` (Next.js App Router helper types)
+- `@workspace/types` → root (reserved for future cross-package types)
+
+### Conventions
+
+- Add a shared type **only when a real cross-package boundary exists**. Keep
+  app-local types in `apps/web`.
+- Prefer `interface` for object contracts, `type` alias for unions/mapped
+  types.
+- Next.js App Router page/layout props come from
+  `@workspace/types/web` (`PageProps`, `LayoutProps`). `params` and
+  `searchParams` are `Promise<...>` per React 19 / Next 16 conventions — do not
+  make them synchronous.
+- Export through the nearest barrel, then the higher-level one.
+- Don't import runtime packages here. The package may depend on
+  `@workspace/constants` for typing constants but nothing framework-specific.
+
+### Build & verify
+
+- `nps lint.packages.types`
+- `nps typecheck.packages.types`
+- `nps build.packages.types`

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,52 @@
+## UI Package Guidelines
+
+For general rules and build commands, see @AGENTS.md.
+
+### Stack
+
+- **shadcn "new-york"** style on **Radix primitives** + **class-variance-authority** + **Tailwind v4**.
+- `lucide-react` icons, `next-themes` for theming, `sonner` for toasts, `framer-motion` for animation.
+- Consumers: `apps/web` (Next.js 16, App Router, RSC-ready).
+
+### Layout
+
+```
+src/
+  components/   # shared React primitives (*.tsx)
+  hooks/        # shared hooks (*.ts)
+  lib/          # utilities (cn lives in lib/utils.ts)
+  styles/       # globals.css (the single Tailwind v4 entry)
+```
+
+### Exports (subpath imports — keep these in sync with package.json `exports`)
+
+- `@workspace/ui/components/*` → `./src/components/*.tsx`
+- `@workspace/ui/hooks/*` → `./src/hooks/*.ts`
+- `@workspace/ui/lib/*` → `./src/lib/*.ts`
+- `@workspace/ui/globals.css` → `./src/styles/globals.css`
+- `@workspace/ui/postcss.config` → `./postcss.config.mjs`
+
+Always import via these subpaths; never deep-import via relative paths from
+`apps/web`.
+
+### Conventions
+
+- Compose with `cn` from `@workspace/ui/lib/utils` (`twMerge` + `clsx`).
+- Variants via `cva`; type them with `VariantProps<typeof variants>`.
+- `asChild` + `Slot.Root` for polymorphic composition; add `data-slot` to the
+  root element for styling hooks.
+- `'use client'` only when the component needs browser APIs / context / hooks.
+  Keep primitives server-component-safe by default.
+- Accessibility: lean on Radix semantics, keyboard support, focus management,
+  and `aria-*` where Radix doesn't cover it.
+- Keep route-specific UI in `apps/web`; this package is for reusable primitives
+  only. Don't pre-abstract — extract only when a second consumer appears.
+
+### Build & verify
+
+`@workspace/ui` has no `build` script (it is transpiled by `apps/web` via
+`next-transpile-modules`). Verify with:
+
+- `nps lint.packages.ui`
+- `nps typecheck.packages.ui`
+- `nps build.web` (transpiles the package end-to-end)


### PR DESCRIPTION
## Summary

Introduce a two-layer opencode configuration for the monorepo:

- **Instructions layer (always loaded)** — per-package `AGENTS.md` files auto-loaded via the `packages/**/AGENTS.md` glob, plus fixes to stale config and the root `AGENTS.md`/`README.md`.
- **Skills layer (on-demand)** — 9 task-driven `SKILL.md` recipes under `.opencode/skills/`, covering both implemented patterns and foresight recipes for patterns the starter does not yet use.

All skills use XML-tagged sections (structure both Anthropic and OpenAI models parse well), front-load trigger keywords in `description`, and verify with real `nps` commands. `name` matches the directory name and passes the `^[a-z0-9]+(-[a-z0-9]+)*$` regex; descriptions are 281-741 chars (within 1-1024).

## Changes by theme

### Config fixes
- `opencode.json`: `*.txt` → `**/*.md` so `docs/instructions/github-workflows/*.md` are actually loaded; add `packages/**/AGENTS.md` so per-package guidelines auto-load.
- `AGENTS.md` (root): fix stale "Yarn workspaces" → "pnpm workspaces"; add `typecheck` and `dev` commands; generalize the app-specific section to point at `@packages/*/AGENTS.md`.

### Per-package AGENTS.md (new, always loaded)
- `packages/ui/AGENTS.md` — shadcn new-york / Radix / CVA / Tailwind v4, subpath exports, `cn` location, RSC-safe defaults.
- `packages/constants/AGENTS.md` — `ErrorCode` + `ErrorMessage {log,notice}` pairing, `NodeErrorMessage`, `rateLimitConfigs`, `as const`, framework-free.
- `packages/types/AGENTS.md` — type-only package, `./web` subpath, `PageProps`/`LayoutProps` with `Promise` params, no runtime code.
- `apps/web/AGENTS.md` (expanded) — full stack (Next 16 + React 19 + Redux Toolkit + next-themes + sonner), layout, conventions, testing.

### Skills (on-demand, flat layout)
**Implementation recipes (7)** — patterns the starter has implementations for:
- `add-ui-component` — shadcn/Radix/CVA primitive + subpath export
- `add-error-code` — `ErrorCode` + `ErrorMessage` pairing, `rateLimitConfigs`
- `add-shared-type` — `@workspace/types/web`, type-only package rules
- `add-redux-slice` — `createSlice`, typed hooks, store registration
- `add-next-route` — App Router, `Promise` params, `(global-not-found)`
- `edit-middleware` — `chain()` + `NextProxyFactory`, `ratelimit`
- `add-web-test` — `customRender`, `vitest.setup.js`, async server components

**Foresight recipes (2)** — patterns not yet used in the starter; marked `category: foresight` in `metadata`:
- `nextjs-rsc-streaming` — React 19 RSC streaming (page-level Promise kickoff, `<Suspense>` + `*Skeleton`, `use()`, `redirect()`/`notFound()` streamed, `loading.tsx` removal + top-loader, session streaming).
- `nextjs-server-action` — two-tier `'use server'` architecture (route `action.ts` + `src/lib/api/**` SDK), `ActionResult<T>` shape, inline toast wrapper with stable id + mutation lock, optimistic-on-success derived render, direct-await for non-form actions, `revalidateTag(tag, 'max')` cache invalidation, notice/log error split.

### README refresh
- Tech Stack: specify Next.js 16 (App Router) + React 19; add State (Redux Toolkit + react-redux), Theming (next-themes), Toasts (sonner via `@workspace/ui`).
- Mention opencode skills in Features; add `.opencode/` to the Project Structure tree.
- Fix the `docs/instructions/` description to "GitHub-workflow guidelines for AI agents".

## Commits

1. `fix(config): correct stale instructions glob and pnpm reference`
2. `docs(packages): add AGENTS.md for ui, constants, and types`
3. `docs(web): expand AGENTS.md with stack, layout, and conventions`
4. `feat: add opencode skills for implementation recipes`
5. `feat: add opencode skills for foresight recipes`
6. `docs: refresh root AGENTS.md with missing commands and package pointers`
7. `docs: refresh README with specific stack and opencode skills`

## Verification

- `nps lint` — 4 tasks, all successful
- `nps build` — 3 tasks (constants tsup, types tsc, web next build), all successful
- `nps test.web` — 1 test, passing
- All 9 skills' frontmatter validated (name/dir match, regex, description length 1-1024)

## Notes

- The `.gitkeep` in `.opencode/skills/` is removed (no longer needed).
- Restart opencode to pick up the new instructions glob and skills — config is loaded once at startup.