### PR TITLE
Add sync-upstream rebase skill

### DIFF
--- a/.opencode/skills/sync-upstream/SKILL.md
+++ b/.opencode/skills/sync-upstream/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: sync-upstream
+description: Use when incorporating upstream changes into this fork via git rebase and resolving the resulting conflicts (取り込む / リベース / 追従). Covers fetch upstream, a backup tag, the rebase ours/theirs swap, the three conflict buckets (textual / type-ripple / silent drift), a coupling audit for fork-only surfaces, nps verification, and the two landing paths (direct-to-main vs follow-up PR). Trigger keywords: "upstream", "rebase", "sync upstream", "merge conflict", "fork", "取り込む", "リベース", "追従".
+license: MIT
+compatibility: opencode
+metadata:
+  category: workflow
+  package: repo
+  stack: git,turbo,monorepo
+---
+
+<Goal>
+
+Replay this fork's commits on top of the latest `upstream/main`, classify what
+the sync touched (textual conflict vs. ripple vs. silent drift), resolve/land it
+on the correct path, and keep a linear, recoverable history.
+
+</Goal>
+
+<Scope>
+
+- Remotes: `origin` = this fork, `upstream` = the repo this fork tracks. This is
+  the git `upstream` remote (`git remote get-url upstream`), NOT the opencode
+  `references.upstream` read-only clone (that one is only for comparison).
+- Layer-agnostic: this fork may itself be the upstream of another fork. "upstream"
+  always = whatever the git `upstream` remote points to. Each layer derives its
+  own surfaces — do not hardcode app/package names.
+- Fork-only surfaces = paths that exist ONLY in this fork (upstream never edits
+  them, so git never conflicts them — this is where silent drift hides). Don't
+  assume them; COMPUTE them for your layer after fetching:
+  - fork-added files:     `git diff --diff-filter=A --name-only upstream/main HEAD`
+  - fork-modified shared: `git diff --diff-filter=M --name-only upstream/main HEAD`
+- Verify with `nps` (turbo fans out to every workspace, incl. fork-only apps).
+
+</Scope>
+
+<Steps>
+
+### 1. Preflight
+
+1. Clean tree — never rebase a dirty tree: `git status` (stash/commit first).
+2. Ensure the remote exists: `git remote get-url upstream` (else
+   `git remote add upstream <url>`).
+3. `git switch main`.
+4. `git fetch upstream`.
+5. Record the base: `BASE=$(git merge-base HEAD upstream/main)`.
+6. Preview:
+   - incoming:   `git log --oneline $BASE..upstream/main`
+   - replayed:   `git log --oneline upstream/main..HEAD`
+   - divergence: `git rev-list --left-right --count HEAD...upstream/main`
+
+### 2. Backup (recovery point)
+
+`git tag backup/pre-rebase-$(date +%Y%m%d-%H%M) main`
+Undo anytime with `git reset --hard <tag>`.
+
+### 3. Rebase
+
+- `git rebase upstream/main`
+- To preserve PR merge commits: `git rebase --rebase-merges upstream/main`
+  (default flattens them — usually fine for a fork).
+
+### 4. Resolve conflicts — mind the ours/theirs SWAP
+
+During rebase the sides are REVERSED vs a merge:
+- `--ours` / `HEAD` = `upstream/main` (the new base) + already-replayed commits.
+- `--theirs`        = the fork commit currently being applied (your change).
+
+Per conflict: reconcile `<<<<<<< ======= >>>>>>>`, then `git add` →
+`git rebase --continue`. Use `git rebase --skip` if the commit is already in
+upstream, `git rebase --abort` to bail to the backup. Never blanket `-X ours` /
+`-X theirs` across the whole rebase.
+
+### 5. Classify — the three buckets (this decides the landing path)
+
+| Bucket | What | Detect with | Path |
+|---|---|---|---|
+| 1. Textual conflict | overlapping edits (`<<<<<<<`) | git marks them during rebase | resolve inline |
+| 2. Type/behaviour ripple | clean apply, but types/build/tests break | `nps typecheck` / `nps build` / `nps test` (turbo hits every workspace) | follow-up PR |
+| 3. Silent drift | clean apply, `nps` green, but a fork-only surface is stale (e.g. a fork-only doc section, or an env var the fork introduced that upstream just renamed) | coupling audit (step 6) + review | follow-up PR |
+
+Decision rule: **bucket 1 only ∧ `nps` green ∧ audit clean → Path 1**, otherwise
+**→ Path 2**.
+
+Conflict vs. follow-up: if git put a marker on it → conflict resolution
+(reconcile the overlapping lines, add NO new behavior). If it applied cleanly but
+is now inconsistent → follow-up implementation. Do NOT fold follow-up work into a
+conflict-resolution commit.
+
+### 6. Coupling audit (bucket 3 — `nps` cannot see this)
+
+1. Compute YOUR fork-only surfaces (don't hardcode):
+   `FORK_ONLY=$(git diff --diff-filter=A --name-only upstream/main HEAD)`
+2. What upstream changed in shared coupling surfaces:
+   `git diff $BASE..upstream/main --stat`   # shared packages, configs, env, docs
+3. For each changed shared symbol/convention (a shared type/constant shape, an env
+   var name, a doc convention), grep your fork-only surfaces for stale refs:
+   `git grep -n "<symbol-or-name>" -- $FORK_ONLY`
+4. Compiles green but now inconsistent (stale docs, old env name, outdated contract
+   impl) = bucket 3 → schedule a follow-up PR.
+
+Semi-mechanical: diff + grep + judgment. `nps` never flags prose/semantic/
+runtime-string drift.
+
+### 7. Land
+
+**Path 1 — direct to main (sync only).** Bucket 1 only, `nps` green, audit clean:
+`git push --force-with-lease origin main`
+(rebase rewrote your commits → force is required; `--force-with-lease` refuses if
+origin moved; the backup tag is your undo.)
+
+**Path 2 — follow-up needed (PR).** Bucket 2/3 present:
+- 2-a (preferred, when the rebase itself is green): land the clean rebase via
+  Path 1 first, then do the adaptation as a NORMAL branch → PR → review/CI → merge
+  on top of the synced main (no force-push).
+- 2-b (when the rebase is red until adapted): keep rebase + adaptation together on
+  `sync/upstream-<date>`, get it green, push the branch, open a PR for review/CI,
+  then land with
+  `git switch main && git reset --hard sync/upstream-<date> && git push --force-with-lease`
+  (keeps linear history; the PR is the review gate). Avoid GitHub squash-merge here
+  — it pushes main off the "upstream + patches" line and complicates the next rebase.
+
+</Steps>
+
+<Verify>
+
+- `nps build` / `nps lint` / `nps typecheck` / `nps test` — green clears bucket 2.
+- Run the coupling audit (step 6) even when green — bucket 3 is invisible to `nps`.
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT `git pull` on main — it creates a merge; this flow is rebase-only.
+- Do NOT confuse the rebase swap: `--ours` = upstream, `--theirs` = your fork commit.
+- Do NOT blanket `-X ours` / `-X theirs` an entire rebase.
+- Do NOT rebase a dirty tree, and do NOT skip the backup tag.
+- Do NOT plain `git push --force` — use `--force-with-lease`.
+- Do NOT force-push a red rebase to main — that's bucket 2/3 → Path 2.
+- `nps` green ≠ done — always run the coupling audit for fork-only drift (bucket 3).
+- Do NOT fold follow-up implementation into a conflict-resolution commit.
+- Do NOT hardcode fork-only paths — compute them (`git diff --diff-filter=A`).
+
+</AntiPatterns>


### PR DESCRIPTION
## Overview

Add a `sync-upstream` opencode skill that documents how to incorporate changes
from an upstream into a fork of this starter via `git rebase`, with conflict
resolution.

This places the **generic fork-sync skill at the root of the fork chain** so every
descendant (direct forks of this repo and deeper layers) inherits it from here,
instead of each fork maintaining its own copy.

## Changes

- Add `.opencode/skills/sync-upstream/SKILL.md`:
  - Preflight, a backup tag, and the rebase steps — with the rebase
    **ours/theirs swap** spelled out (`--ours` = upstream, `--theirs` = the fork
    commit).
  - **Three-bucket classification**: textual conflict, type/behaviour ripple
    (caught by `nps`), and silent drift in fork-only surfaces.
  - **Coupling audit** (`git diff` + `git grep`) for drift `nps` cannot see.
  - **Two landing paths**: direct-to-main sync vs follow-up PR.
  - Layer-agnostic: **computes** fork-only surfaces instead of hardcoding names.

## Impact Scope

- **Configuration only**: a new opencode skill. Loaded at startup — restart
  opencode to pick it up. No app/runtime code changes.
- This repo (the root) has no upstream itself, so it does not run the skill; it
  ships it as inheritable guidance for its forks (alongside the existing shared
  skills).

## Notes

- Forks that already carry a local copy (added before this) will reconcile it on
  their next sync: the redundant add becomes a trivial add/add conflict, resolved
  by `git rebase --skip` so the single source of truth is this repo.
- The skill is written generically; the `nps` verification commands exist here as
  well, so the body applies unchanged.
