### PR TITLE
Genericize root opencode skills

### DIFF
--- a/.opencode/skills/fork-layer-placement/SKILL.md
+++ b/.opencode/skills/fork-layer-placement/SKILL.md
@@ -22,9 +22,8 @@ reaches every fork that needs it without duplication or sync conflicts.
   conventions, configs — anything multiple forks might inherit.
 - NOT app features / layer-specific code: those live in whatever fork uses them
   (placement is obvious — don't over-hoist).
-- A "fork chain" = repos linked by `upstream` remotes (this family:
-  `turborepo-starter` → `-with-cloudrun` → `-proxy` → `-discordbot`, with
-  `-legacy` as a direct sibling of `-with-cloudrun`).
+- A "fork chain" = repos linked by `upstream` remotes: a root (no upstream), its
+  direct forks, their forks, and sibling forks that share a parent.
 - Pairs with `sync-upstream`: this decides where to ORIGINATE a change;
   `sync-upstream` PROPAGATES it downward.
 
@@ -39,22 +38,24 @@ reaches every fork that needs it without duplication or sync conflicts.
    - Generic / tech-agnostic, every fork could use it → root-ward.
    - Tied to a capability introduced at layer N (only N + descendants have it) →
      layer N.
-   - Personal / machine-specific, not project-shared → global
-     `~/.config/opencode/skills/`.
+   - Personal / machine-specific, not project-shared → a user-level (global)
+     scope, outside the shared repos.
 3. **Target layer = the shallowest layer that BOTH (a) owns/contains what the
    change depends on AND (b) is a common ancestor of every repo that needs it.**
    If the needers include a sibling that branches higher, go up to their common
    ancestor.
-4. **Repo vs global.** Shared & versioned with the family → the target repo. Pure
-   personal cross-repo tooling with no dependency on any repo's code → global.
+4. **Repo vs global.** Shared & versioned with the chain → the target repo. Pure
+   personal cross-repo tooling with no dependency on any repo's code → a
+   user-level (global) scope.
 5. **Place it once, let it propagate.** Add it at the target layer; descendants
    inherit via `sync-upstream`. Do not copy it into multiple layers.
 
 Worked examples:
-- `sync-upstream` — generic git procedure every fork needs (incl. the `-legacy`
-  sibling) → common ancestor = the root.
-- Cloud Run skills — depend on Cloud Run, introduced at `-with-cloudrun` (the root
-  and `-legacy` lack it) → that layer, inherited by `-proxy` / `-discordbot`.
+- A generic, tech-agnostic procedure every fork needs (e.g. a fork-sync rebase
+  guide) → the root, since every fork — including siblings — descends from it.
+- A skill for a capability introduced one layer down (e.g. a deploy target only
+  some forks add) → that layer; descendants inherit it, while the root and
+  siblings that lack the capability don't carry it.
 
 </Steps>
 
@@ -74,14 +75,14 @@ Before implementing, confirm the chosen layer:
 <AntiPatterns>
 
 - Placing a generic, every-fork capability in a mid-chain layer — siblings that
-  branch higher won't inherit it (the `-legacy` trap).
+  branch higher won't inherit it (the sibling-fork trap).
 - Duplicating the same file across layers — guarantees add/add conflicts on every
   sync.
 - "Moving" something with a delete-commit in a fork — on the next rebase the
   delete removes the inherited copy. Instead add at the correct layer and let the
   redundant copy reconcile via `git rebase --skip` (see `sync-upstream`).
-- Putting layer-specific tooling (e.g. Cloud Run) at the generic root — dead
-  weight there, irrelevant to siblings.
+- Putting layer-specific tooling at the generic root — dead weight there,
+  irrelevant to siblings that lack the capability.
 - Treating app features as "shared" — they belong in the fork that uses them.
 - Reaching for global when forks/collaborators need it (or repo when it's purely
   personal cross-chain tooling) — match the tier to the audience.

--- a/.opencode/skills/sync-upstream/SKILL.md
+++ b/.opencode/skills/sync-upstream/SKILL.md
@@ -19,9 +19,9 @@ on the correct path, and keep a linear, recoverable history.
 
 <Scope>
 
-- Remotes: `origin` = this fork, `upstream` = the repo this fork tracks. This is
-  the git `upstream` remote (`git remote get-url upstream`), NOT the opencode
-  `references.upstream` read-only clone (that one is only for comparison).
+- Remotes: `origin` = this fork, `upstream` = the repo this fork tracks
+  (`git remote get-url upstream`). Rebase always uses this git remote — not any
+  read-only mirror your tooling may keep for browsing the upstream.
 - Layer-agnostic: this fork may itself be the upstream of another fork. "upstream"
   always = whatever the git `upstream` remote points to. Each layer derives its
   own surfaces — do not hardcode app/package names.


### PR DESCRIPTION
## Overview

Genericize the two root opencode skills (`sync-upstream`, `fork-layer-placement`).
As merged, they leaked specifics of one particular fork family and of the opencode
dotconfig — which the root must not carry, and which contradicts the
`fork-layer-placement` rule itself.

## Changes

- **fork-layer-placement**:
  - Replace the hardcoded family lineage
    (`-with-cloudrun` / `-proxy` / `-discordbot` / `-legacy`) with a generic
    definition of a fork chain.
  - Replace the Cloud Run worked example with a generic "capability introduced one
    layer down" example.
  - Drop the literal `~/.config/opencode/skills/` path → "a user-level (global)
    scope".
  - `-legacy trap` → `sibling-fork trap`.
- **sync-upstream**:
  - Drop the `opencode references.upstream` clause; describe the git `upstream`
    remote generically.

## Impact Scope

- **Configuration only**: opencode skill text. Loaded at startup — restart to pick
  up. No app/runtime code changes.
- `nps` / `turbo` references are intentionally kept — they are the root starter's
  own tooling, not fork-family specifics.

## Notes

- Forward-fix (not an amend): the original PRs were already merged, so this lands
  as a normal `refactor:` commit rather than rewriting `main`.
- Downstream forks that want a specific note (e.g. their `references.upstream`
  mirror) can add it as a fork-local enhancement — per the placement rule, the
  specific note belongs at the layer that has it, not at the root.
