### PR TITLE
Document streaming sections that own mutating state

### DIFF
--- a/.opencode/skills/nextjs-rsc-streaming/SKILL.md
+++ b/.opencode/skills/nextjs-rsc-streaming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nextjs-rsc-streaming
-description: Use when implementing React Server Component streaming in apps/web (Next.js 16 + React 19) — page-level Promise kickoff, Suspense boundaries with colocated *Skeleton fallbacks, use() in client components, redirect()/notFound() streamed through boundaries, and the loading.tsx-removal + top-loader pattern. FORESIGHT recipe: the starter does not currently use this; adopt when a page fetches data and you want progressive streaming. Trigger keywords: "RSC streaming", "Suspense", "use()", "Promise.all", "loading.tsx", "streaming", "React 19".
+description: Use when implementing React Server Component streaming in apps/web (Next.js 16 + React 19) — page-level Promise kickoff, Suspense boundaries with colocated *Skeleton fallbacks, use() in client components, redirect()/notFound() streamed through boundaries, and the loading.tsx-removal + top-loader pattern, plus streaming client sections that own mutating state (load more, pagination). FORESIGHT recipe: the starter does not currently use this; adopt when a page fetches data and you want progressive streaming. Trigger keywords: "RSC streaming", "Suspense", "use()", "Promise.all", "loading.tsx", "streaming", "React 19", "load more", "pagination".
 license: MIT
 compatibility: opencode
 metadata:
@@ -132,6 +132,46 @@ it is codified in `apps/web/AGENTS.md`.
    a helper (e.g. `unwrapOrNull(promise)`) so one endpoint failure doesn't
    break the whole page — the affected boundary just renders its empty state.
 
+10. **Stream client sections that also own mutating state.** When a streaming
+    client component must also own mutating state (e.g. a "load more" button
+    that appends rows, client-side pagination), split it into a **non-suspending
+    shell** that holds the state and **suspending children** that call `use()`:
+    ```tsx
+    'use client';
+    import { Suspense, use, useState } from 'react';
+
+    export function ListShell({ dataPromise }: { dataPromise: Promise<Page<Item>> }) {
+      const [extra, setExtra] = useState<Item[]>([]); // accumulation lives HERE
+      return (
+        <>
+          <p>
+            Showing{' '}
+            <Suspense fallback={<CountChip />}>
+              <Shown dataPromise={dataPromise} extra={extra} />
+            </Suspense>{' '}
+            items
+          </p>
+          <Suspense fallback={<TableSkeleton />}>
+            <Table dataPromise={dataPromise} extra={extra} onAppend={setExtra} />
+          </Suspense>
+        </>
+      );
+    }
+
+    function Shown({ dataPromise, extra }: { dataPromise: Promise<Page<Item>>; extra: Item[] }) {
+      const first = use(dataPromise); // suspends until resolved
+      return <>{first.data.length + extra.length}</>;
+    }
+    ```
+    - The shell NEVER calls `use()` — it stays painted so labels and buttons
+      remain visible while the children stream.
+    - Multiple children MAY `use()` the SAME promise — React caches the result,
+      so each child resolves together without re-fetching.
+    - Hoist the mutating accumulation into the shell so the count and the list
+      share one source of truth across mutations.
+    - Each `<Suspense>` fallback should MIRROR the final layout (a count chip,
+      a row skeleton) to avoid layout shift when the children resolve.
+
 </Steps>
 
 <Verify>
@@ -143,6 +183,9 @@ it is codified in `apps/web/AGENTS.md`.
   (no full-page skeleton flash).
 - Confirm `redirect()`/`notFound()` stream through the correct boundary
   without aborting siblings.
+- For sections that own mutating state (load more, pagination), confirm the
+  count and list stay in sync after a mutation — the accumulation must live in
+  a non-suspending shell.
 
 </Verify>
 
@@ -159,5 +202,9 @@ it is codified in `apps/web/AGENTS.md`.
 - Do NOT create a `<Suspense>` without a colocated `*Skeleton` fallback —
   `fallback={null}` is acceptable only for invisible guards (e.g. session
   guards), not for user-visible content.
+- Do NOT own mutating state (load-more accumulation, pagination) inside a client
+  component that ALSO calls `use()` — it suspends and replaces the whole section
+  (chrome included) with the fallback. Hoist the state into a non-suspending
+  shell and push `use()` into children.
 
 </AntiPatterns>


### PR DESCRIPTION
## Overview

Adds a step (and matching anti-pattern) to the `nextjs-rsc-streaming` skill for streaming client components that also own mutating state — e.g. a "load more" button that appends rows, or client-side pagination.

## Changes

- **New Step 10**: split such a component into a non-suspending shell (hoists the accumulation) and suspending children that call `use()`. Notes that multiple children may `use()` the same promise (React caches it), and each `<Suspense>` fallback should mirror the final layout to avoid shift.
- **New anti-pattern**: don't own mutating state inside a client component that also calls `use()` — it suspends the whole section (chrome included).
- **Verify**: confirm count and list stay in sync after a mutation.
- **description/keywords**: mention "load more" / "pagination" triggers.

## Impact Scope

- Documentation only (a foresight skill under `.opencode/skills/`).
- No code, config, or dependency changes.

## Notes

Generalizes a pattern hit while streaming a count label ("Showing N of M") alongside a "load more" list: the count and the rows must share one source of truth across mutations, so the accumulation has to live in a non-suspending shell while `use()` is pushed into children. Pure React 19 + Next 16 — no app-specific context in the skill itself.