### PR TITLE
Fix web Dockerfile turbo prune version

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,7 +16,7 @@ RUN corepack enable
 COPY . .
 
 # Prune unnecessary files and isolate the web subworkspace
-RUN pnpm dlx turbo@2.3.3 prune --scope=web --docker
+RUN pnpm dlx turbo@2.9.14 prune --scope=web --docker
 
 ###############################################################################
 # Installer stage: Add lockfile and package.json's of isolated subworkspace   #


### PR DESCRIPTION
## Overview

Aligns the `turbo prune` tool version pinned in `apps/web/Dockerfile` with the
root `package.json` turbo version (`2.9.14`). The builder stage still pinned the
old `turbo@2.3.3`, left over from before the Dependabot turbo bump.

## Changes

- `apps/web/Dockerfile`: `pnpm dlx turbo@2.3.3 prune` → `turbo@2.9.14 prune`

## Impact Scope

- **Configuration / Build**: Docker image build for `apps/web` only. No runtime,
  API, DB, or env-var changes.

## Notes

- This file is owned by this base starter and inherited verbatim by downstream
  forks (e.g. `turborepo-starter-with-cloudrun` and its forks). Fixing it here
  lets the correction propagate down via upstream sync instead of being
  duplicated per fork.