### PR TITLE
Define bugfix convention

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -1,7 +1,8 @@
 module.exports = {
   types: [
     { value: "feat", name: "feat:     A new feature" },
-    { value: "fix", name: "fix:      A bug fix" },
+    { value: "fix", name: "fix:      An enhancement or adjustment" },
+    { value: "bugfix", name: "bugfix:   A bug fix" },
     { value: "docs", name: "docs:     Documentation only changes" },
     {
       value: "style",
@@ -66,7 +67,7 @@ module.exports = {
   },
 
   allowCustomScopes: true,
-  allowBreakingChanges: ["feat", "fix"],
+  allowBreakingChanges: ["feat", "fix", "bugfix"],
   // skip any questions you want
   skipQuestions: ["body"],
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,9 +11,9 @@ Describe the changes in the following format:
   - Detailed change 1
   - Detailed change 2
 
-- ### Fix of YY feature
-  - Explanation of the fix
-  - Effect of the fix
+- ### Improvement or bugfix of YY feature
+  - Explanation of the change
+  - Effect of the change
 -->
 
 ## Breaking Changes

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -37,13 +37,13 @@ version-resolver:
   minor:
     labels:
       - "🌱feature"
-      - "🐞hotfix"
   # Specifies labels that trigger a patch version bump.
   patch:
     labels:
       - "📝documentation"
       - "⚒️enhancement"
       - "🐛bug"
+      - "🐞hotfix"
   # Specifies the default version bump when no labels match.
   default: patch
 
@@ -56,11 +56,16 @@ autolabeler:
   # Automatically applies the "⚒️enhancement" label based on branch naming patterns.
   - label: "⚒️enhancement"
     branch:
-      - "/(improve|refactor|enhancement)[/-].+/"
+      - "/^(fix|enhance|improve|refactor|enhancement)[/-].+/"
+
+  # Automatically applies the "🐛bug" label based on branch naming patterns.
+  - label: "🐛bug"
+    branch:
+      - "/^bugfix[/-].+/"
 
   # Automatically applies the "📝documentation" label based on branch naming patterns or file changes.
   - label: "📝documentation"
     branch:
-      - "/(doc|document|documentation)[/-].+/"
+      - "/^(doc|document|documentation)[/-].+/"
     files:
       - "*.md"

--- a/.github/workflows/assign-labels.yml
+++ b/.github/workflows/assign-labels.yml
@@ -27,6 +27,8 @@ jobs:
           elif [ $branch_type == 'docs' ]; then
             label_name="📝documentation"
           elif [ $branch_type == 'fix' ]; then
+            label_name="⚒️enhancement"
+          elif [ $branch_type == 'bugfix' ]; then
             label_name="🐛bug"
           elif [ $branch_type == 'hotfix' ]; then
             label_name="🐞hotfix"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -26,6 +26,7 @@ module.exports = {
         "docs",
         "feat",
         "fix",
+        "bugfix",
         "perf",
         "refactor",
         "revert",

--- a/docs/github-actions/assign-labels.md
+++ b/docs/github-actions/assign-labels.md
@@ -6,7 +6,8 @@
 
 - Pull request must be **opened** (not updated/reopened)
 - Branch must follow naming convention: `{type}/{description}`
-- Supported branch types: `feat`, `enhance`, `docs`, `fix`, `hotfix`
+- Supported branch types: `feat`, `enhance`, `docs`, `fix`, `bugfix`,
+  `hotfix`
 - Corresponding labels must exist in the repository
 
 ## How It Works
@@ -19,7 +20,8 @@ type (first segment before `/`):
 | `feat/`     | 🌱feature       |
 | `enhance/`  | ⚒️enhancement   |
 | `docs/`     | 📝documentation |
-| `fix/`      | 🐛bug           |
+| `fix/`      | ⚒️enhancement   |
+| `bugfix/`   | 🐛bug           |
 | `hotfix/`   | 🐞hotfix        |
 
 ### Process

--- a/docs/github-actions/release-drafter.md
+++ b/docs/github-actions/release-drafter.md
@@ -53,15 +53,16 @@ Version bumps are determined by labels on pull requests:
 | Version Type | Trigger Labels                                        |
 | ------------ | ----------------------------------------------------- |
 | Major        | `🌟major`                                             |
-| Minor        | `🌱feature`, `🐞hotfix`                               |
-| Patch        | `📝documentation`, `⚒️enhancement`, `🐛bug` (default) |
+| Minor        | `🌱feature`                                           |
+| Patch        | `📝documentation`, `⚒️enhancement`, `🐛bug`, `🐞hotfix` (default) |
 
 ### Auto-labeling Rules
 
 Labels are automatically applied based on branch naming patterns or file
 changes:
 
-1. **Enhancement**: Branch name matches `/improve/`, `/refactor/`, or
-   `/enhancement/`
-2. **Documentation**: Branch name matches `/doc/`, `/document/`, or
-   `/documentation/` OR changes `.md` files
+1. **Enhancement**: Branch name starts with `fix/`, `enhance/`, `improve/`,
+   `refactor/`, or `enhancement/`
+2. **Bug Fix**: Branch name starts with `bugfix/`
+3. **Documentation**: Branch name starts with `doc/`, `document/`, or
+   `documentation/` OR changes `.md` files

--- a/docs/instructions/github-workflows/TASK.md
+++ b/docs/instructions/github-workflows/TASK.md
@@ -15,7 +15,7 @@ On Issue:
 - Create PR with "Closes #{issue_number}"
 
 **BRANCH NAMING**: Use format: <type>/<description> Valid types: feat, fix,
-hotfix, docs, enhance, improve, refactor
+bugfix, hotfix, docs, enhance, improve, refactor
 
 **COMMIT MESSAGES**: Follow Conventional Commits:
 
@@ -27,7 +27,8 @@ hotfix, docs, enhance, improve, refactor
 <footer>
 ```
 
-- Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+- Types: feat, fix, bugfix, docs, style, refactor, perf, test, build, ci,
+  chore, revert
 - Subject: Use imperative mood (add, fix, refactor), keep concise
 - Body: Explain why and what changed
 - Footer: Reference issues (Closes #123, Fixes #456)
@@ -41,7 +42,7 @@ hotfix, docs, enhance, improve, refactor
 **PR DESCRIPTION**: Include:
 
 - Overview: What this PR does
-- Changes: Detailed changes organized by feature/fix
+- Changes: Detailed changes organized by feature/improvement/bugfix
 - Impact Scope: UI, Database, API, Configuration, Environment variables, Code
   cleanup
 - Notes: Implementation concerns or additional tasks
@@ -63,7 +64,7 @@ For feature implementation:
 
 For bug fixes:
 
-- `fix: resolve navigation router issue` (core fix)
+- `bugfix: resolve navigation router issue` (core bug fix)
 - `test: add navigation regression tests` (prevention)
 
 **GUIDELINES**:


### PR DESCRIPTION
## Overview

Update the repository conventions so `fix` is treated as an enhancement or adjustment, while `bugfix` is used for normal bug fixes.

## Changes

- ### Convention updates
  - Add `bugfix` as an allowed commit type
  - Reclassify `fix/*` branches as `⚒️enhancement`
  - Map `bugfix/*` branches to `🐛bug`
  - Move `🐞hotfix` release bumps from minor to patch

- ### Documentation updates
  - Align workflow docs with the new branch and label mapping
  - Update task instructions to use `bugfix` for bug-fix commits
  - Adjust the PR template wording away from generic `fix` language

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

<details>
  <summary>nps lint</summary>

  Passed.
</details>

<details>
  <summary>YAML parse</summary>

  Passed for `.github/release-drafter.yml` and `.github/workflows/assign-labels.yml`.
</details>

## Screenshots

N/A

## Notes

No related issues were detected.
