### PR TITLE
Add RSC streaming demo and route progress

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,11 +17,12 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
     "@reduxjs/toolkit": "^2.4.0",
-    "@workspace/ui": "workspace:*",
     "@workspace/constants": "workspace:*",
+    "@workspace/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "next": "^16.2.3",
     "next-themes": "^0.4.4",
+    "nextjs-toploader": "^3.9.17",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-redux": "^9.1.2"
@@ -38,8 +39,8 @@
     "@workspace/eslint": "workspace:*",
     "@workspace/prettier": "workspace:*",
     "@workspace/tsconfig": "workspace:*",
-    "@workspace/vitest": "workspace:*",
     "@workspace/types": "workspace:*",
+    "@workspace/vitest": "workspace:*",
     "copy-webpack-plugin": "^14.0.0",
     "next-transpile-modules": "10.0.1",
     "whatwg-fetch": "^3.6.20"

--- a/apps/web/src/app/(app)/showcase/page.tsx
+++ b/apps/web/src/app/(app)/showcase/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { ArrowDown, Blocks, Layers3, Zap } from 'lucide-react';
+import { ArrowDown, ArrowRight, Blocks, Layers3, Zap } from 'lucide-react';
 import { Button } from '@workspace/ui/components/button';
 import { Container, Heading, HStack, Screen, Section, Text, VStack } from '@/components';
 import { StateFeedbackDemo, ThemeLayoutDemo } from './_components';
@@ -54,12 +54,20 @@ export default async function ShowcasePage() {
               ))}
             </div>
 
-            <Button asChild variant='outline' className='w-fit'>
-              <Link href='#state'>
-                Start exploring
-                <ArrowDown />
-              </Link>
-            </Button>
+            <HStack collapse gap={3} className='w-full sm:w-auto'>
+              <Button asChild variant='outline' className='w-full sm:w-auto'>
+                <Link href='#state'>
+                  Start exploring
+                  <ArrowDown />
+                </Link>
+              </Button>
+              <Button asChild className='w-full sm:w-auto'>
+                <Link href='/showcase/streaming' prefetch={false}>
+                  Open streaming demo
+                  <ArrowRight />
+                </Link>
+              </Button>
+            </HStack>
           </VStack>
         </Container>
       </Section>

--- a/apps/web/src/app/(app)/showcase/streaming/_components/StreamResult.tsx
+++ b/apps/web/src/app/(app)/showcase/streaming/_components/StreamResult.tsx
@@ -1,0 +1,35 @@
+import { CircleCheck } from 'lucide-react';
+import { HStack, Text, VStack } from '@/components';
+
+export interface StreamingDemoResult {
+  delayMs: number;
+  description: string;
+  title: string;
+}
+
+interface StreamResultProps {
+  resultPromise: Promise<StreamingDemoResult>;
+}
+
+export const StreamResult = async ({ resultPromise }: StreamResultProps) => {
+  const result = await resultPromise;
+
+  return (
+    <VStack gap={4} className='min-h-36 justify-between border-t pt-5'>
+      <VStack gap={2}>
+        <HeadingRow title={result.title} />
+        <Text variant='muted'>{result.description}</Text>
+      </VStack>
+      <span className='w-fit rounded-full bg-primary/10 px-3 py-1 font-mono text-xs font-semibold text-primary'>
+        resolved after {result.delayMs.toLocaleString('en-US')} ms
+      </span>
+    </VStack>
+  );
+};
+
+const HeadingRow = ({ title }: Pick<StreamingDemoResult, 'title'>) => (
+  <HStack gap={2}>
+    <CircleCheck className='size-4 text-primary' aria-hidden='true' />
+    <h2 className='font-semibold'>{title}</h2>
+  </HStack>
+);

--- a/apps/web/src/app/(app)/showcase/streaming/_components/StreamResultSkeleton.tsx
+++ b/apps/web/src/app/(app)/showcase/streaming/_components/StreamResultSkeleton.tsx
@@ -1,0 +1,22 @@
+interface StreamResultSkeletonProps {
+  label: string;
+}
+
+export const StreamResultSkeleton = ({ label }: StreamResultSkeletonProps) => (
+  <div
+    role='status'
+    aria-busy='true'
+    aria-label={`${label} is streaming`}
+    className='min-h-36 border-t pt-5'
+  >
+    <div className='animate-pulse space-y-4 motion-reduce:animate-none'>
+      <div className='h-5 w-2/3 rounded bg-muted' />
+      <div className='space-y-2'>
+        <div className='h-4 w-full rounded bg-muted' />
+        <div className='h-4 w-4/5 rounded bg-muted' />
+      </div>
+      <div className='h-6 w-36 rounded-full bg-primary/10' />
+    </div>
+    <span className='sr-only'>Streaming {label}</span>
+  </div>
+);

--- a/apps/web/src/app/(app)/showcase/streaming/_components/index.ts
+++ b/apps/web/src/app/(app)/showcase/streaming/_components/index.ts
@@ -1,0 +1,2 @@
+export { StreamResult, type StreamingDemoResult } from './StreamResult';
+export { StreamResultSkeleton } from './StreamResultSkeleton';

--- a/apps/web/src/app/(app)/showcase/streaming/page.tsx
+++ b/apps/web/src/app/(app)/showcase/streaming/page.tsx
@@ -1,0 +1,100 @@
+import { Suspense } from 'react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { connection } from 'next/server';
+import { ArrowLeft, Radio } from 'lucide-react';
+import { Button } from '@workspace/ui/components/button';
+import { Container, Heading, HStack, Screen, Section, Text, VStack } from '@/components';
+import { StreamResult, StreamResultSkeleton, type StreamingDemoResult } from './_components';
+
+export const metadata: Metadata = {
+  title: 'RSC Streaming',
+  description: 'See independent React Server Component boundaries stream into the page.',
+};
+
+const resolveAfter = (result: StreamingDemoResult) =>
+  new Promise<StreamingDemoResult>((resolve) => {
+    setTimeout(() => resolve(result), result.delayMs);
+  });
+
+export default async function StreamingPage() {
+  await connection();
+
+  const stages = [
+    {
+      index: '01',
+      label: 'Primary payload',
+      resultPromise: resolveAfter({
+        delayMs: 800,
+        title: 'Primary payload arrived',
+        description: 'This boundary resolves first without waiting for the slower sibling below.',
+      }),
+    },
+    {
+      index: '02',
+      label: 'Secondary payload',
+      resultPromise: resolveAfter({
+        delayMs: 1800,
+        title: 'Secondary payload arrived',
+        description: 'Independent work can finish later while the rest of the page stays usable.',
+      }),
+    },
+  ] as const;
+
+  return (
+    <Screen smooth hideScrollbar>
+      <Section className='grow justify-center py-12 sm:py-28'>
+        <Container>
+          <VStack gap={8}>
+            <VStack gap={4}>
+              <HStack gap={2} className='font-mono text-xs uppercase tracking-widest text-primary'>
+                <Radio className='size-4' aria-hidden='true' />
+                Live server stream
+              </HStack>
+              <Heading>Watch the server arrive in stages.</Heading>
+              <Text variant='lead' measure='prose'>
+                The route shell renders immediately. Each card then unwraps its own server promise
+                inside an independent Suspense boundary.
+              </Text>
+            </VStack>
+
+            <div className='grid gap-4 lg:grid-cols-2'>
+              {stages.map((stage) => (
+                <VStack
+                  asChild
+                  key={stage.index}
+                  gap={6}
+                  className='rounded-xl border bg-card/80 p-5 shadow-sm backdrop-blur-sm sm:p-6'
+                >
+                  <article>
+                    <HStack justify='between' className='w-full'>
+                      <span className='font-mono text-xs text-muted-foreground'>{stage.index}</span>
+                      <span className='font-mono text-xs text-muted-foreground'>{stage.label}</span>
+                    </HStack>
+                    <Suspense fallback={<StreamResultSkeleton label={stage.label} />}>
+                      <StreamResult resultPromise={stage.resultPromise} />
+                    </Suspense>
+                  </article>
+                </VStack>
+              ))}
+            </div>
+
+            <div className='rounded-xl border border-dashed bg-muted/30 p-4 sm:p-5'>
+              <Text variant='muted' measure='prose'>
+                The top progress bar covers navigation to this route. These skeletons cover server
+                work that continues streaming after the route shell appears.
+              </Text>
+            </div>
+
+            <Button asChild variant='outline' className='w-fit'>
+              <Link href='/showcase'>
+                <ArrowLeft />
+                Back to showcase
+              </Link>
+            </Button>
+          </VStack>
+        </Container>
+      </Section>
+    </Screen>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import NextTopLoader from 'nextjs-toploader';
 import type { LayoutProps } from '@workspace/types/web';
 import { Toaster } from '@workspace/ui/components/sonner';
 import '@workspace/ui/globals.css';
@@ -63,6 +64,7 @@ export default async function RootLayout(props: LayoutProps) {
         <ReduxToolProvider>
           <ThemeProvider attribute='class' defaultTheme='system' enableSystem>
             {props.children}
+            <NextTopLoader color='var(--primary)' height={2} shadow={false} showSpinner={false} />
             <Toaster mobileOffset={{ bottom: 'calc(5rem + env(safe-area-inset-bottom))' }} />
           </ThemeProvider>
         </ReduxToolProvider>

--- a/apps/web/src/components/Navigation/BottomNav.tsx
+++ b/apps/web/src/components/Navigation/BottomNav.tsx
@@ -75,7 +75,9 @@ export const BottomNav = ({ variant = 'docked' }: NavigationVariantProps) => {
     >
       <ul className='flex items-stretch'>
         {navItems.map((item) => {
-          const active = !item.external && pathname === item.href;
+          const active =
+            !item.external &&
+            (pathname === item.href || (item.href !== '/' && pathname.startsWith(`${item.href}/`)));
           const Icon = item.icon;
           return (
             <li key={item.href} className='flex-1'>

--- a/apps/web/src/components/Navigation/Toolbar.tsx
+++ b/apps/web/src/components/Navigation/Toolbar.tsx
@@ -9,6 +9,7 @@ import { HStack } from '../Stack';
 import { ThemeToggle } from '../Theme';
 import { navItems } from './items';
 import { navigationSurfaceVariants } from './styles';
+import { ToolbarLink } from './ToolbarLink';
 import type { NavigationVariantProps } from './types';
 
 const toolbarVariants = cva('relative z-40 hidden sm:block', {
@@ -73,12 +74,7 @@ export const Toolbar = ({ variant = 'docked' }: NavigationVariantProps) => (
               .filter((item) => item.href !== '/')
               .map((item) => (
                 <Button key={item.href} asChild variant='ghost' size='sm'>
-                  <Link
-                    href={item.href}
-                    {...(item.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                  >
-                    {item.label}
-                  </Link>
+                  <ToolbarLink href={item.href} label={item.label} external={item.external} />
                 </Button>
               ))}
             <ThemeToggle />

--- a/apps/web/src/components/Navigation/ToolbarLink.tsx
+++ b/apps/web/src/components/Navigation/ToolbarLink.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '@workspace/ui/lib/utils';
+
+interface ToolbarLinkProps extends Omit<ComponentProps<typeof Link>, 'href'> {
+  external?: boolean;
+  href: string;
+  label: string;
+}
+
+export const ToolbarLink = ({ className, external, href, label, ...props }: ToolbarLinkProps) => {
+  const pathname = usePathname();
+  const active =
+    !external && (pathname === href || (href !== '/' && pathname.startsWith(`${href}/`)));
+
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={cn(
+        className,
+        active && 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary',
+      )}
+      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      {...props}
+    >
+      {label}
+    </Link>
+  );
+};

--- a/apps/web/src/tests/app/showcase/page.test.tsx
+++ b/apps/web/src/tests/app/showcase/page.test.tsx
@@ -15,6 +15,10 @@ describe('ShowcasePage', () => {
     expect(
       screen.getByRole('heading', { name: 'One system, multiple modes.' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open streaming demo/i })).toHaveAttribute(
+      'href',
+      '/showcase/streaming',
+    );
   });
 
   it('updates the shared counter from the playground', async () => {

--- a/apps/web/src/tests/app/showcase/streaming/StreamResult.test.tsx
+++ b/apps/web/src/tests/app/showcase/streaming/StreamResult.test.tsx
@@ -1,0 +1,36 @@
+import '@testing-library/dom';
+import { act, render, screen } from '../../../testUtils';
+import {
+  StreamResult,
+  StreamResultSkeleton,
+} from '../../../../app/(app)/showcase/streaming/_components';
+
+describe('RSC streaming result', () => {
+  it('renders a resolved server payload', async () => {
+    const result = await StreamResult({
+      resultPromise: Promise.resolve({
+        delayMs: 800,
+        title: 'Primary payload arrived',
+        description: 'The first boundary completed.',
+      }),
+    });
+
+    await act(async () => {
+      render(result);
+    });
+
+    expect(screen.getByRole('heading', { name: 'Primary payload arrived' })).toBeInTheDocument();
+    expect(screen.getByText('resolved after 800 ms')).toBeInTheDocument();
+  });
+
+  it('announces a pending server payload', async () => {
+    await act(async () => {
+      render(<StreamResultSkeleton label='Secondary payload' />);
+    });
+
+    expect(screen.getByRole('status', { name: 'Secondary payload is streaming' })).toHaveAttribute(
+      'aria-busy',
+      'true',
+    );
+  });
+});

--- a/apps/web/src/tests/components/Navigation/BottomNav.test.tsx
+++ b/apps/web/src/tests/components/Navigation/BottomNav.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/dom';
+import { act, render, screen } from '../../testUtils';
+import { BottomNav } from '../../../components/Navigation';
+import { ToolbarLink } from '../../../components/Navigation/ToolbarLink';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/showcase/streaming',
+}));
+
+describe('BottomNav', () => {
+  it('keeps the parent navigation item active on a nested route', async () => {
+    await act(async () => {
+      render(<BottomNav />);
+    });
+
+    expect(screen.getByRole('link', { name: 'Showcase' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks the parent toolbar item active on a nested route', async () => {
+    await act(async () => {
+      render(<ToolbarLink href='/showcase' label='Showcase' />);
+    });
+
+    expect(screen.getByRole('link', { name: 'Showcase' })).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nextjs-toploader:
+        specifier: ^3.9.17
+        version: 3.9.17(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.1
         version: 19.2.7
@@ -4249,6 +4252,13 @@ packages:
       sass:
         optional: true
 
+  nextjs-toploader@3.9.17:
+    resolution: {integrity: sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==}
+    peerDependencies:
+      next: '>= 6.0.0'
+      react: '>= 16.0.0'
+      react-dom: '>= 16.0.0'
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -4277,6 +4287,9 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nprogress@0.2.0:
+    resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
@@ -9541,6 +9554,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nextjs-toploader@3.9.17(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      next: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      nprogress: 0.2.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   node-domexception@1.0.0: {}
 
   node-exports-info@1.6.0:
@@ -9568,6 +9589,8 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  nprogress@0.2.0: {}
 
   nwsapi@2.2.24: {}
 


### PR DESCRIPTION
## Overview

Adds a theme-aware route progress bar and an RSC streaming showcase that demonstrates how navigation feedback and independent Suspense boundaries complement each other.

## Changes

- ### Add navigation progress
  - Integrate `nextjs-toploader` in the root layout.
  - Match the existing primary theme color without adding a spinner or shadow.

- ### Add an RSC streaming demo
  - Add `/showcase/streaming` with two deterministic server promises.
  - Resolve each promise inside an independent Suspense boundary with an accessible, layout-matched fallback.
  - Keep the route shell visible while streamed sections complete.

- ### Extend Showcase navigation
  - Add a non-prefetched entry point so the initial route transition remains observable.
  - Preserve the Showcase active state on nested routes in both desktop and mobile navigation.
  - Add regression coverage for the entry point, streamed result states, and nested navigation state.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [x] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

<details>
  <summary>Web verification</summary>

- `nps test.web`
- `nps lint.web`
- `nps typecheck.web`
- `nps build.web`

All checks pass.
</details>

## Screenshots

Verified the Showcase and streaming route at 1440x900 and 375x812. The intermediate state shows the primary result while the secondary boundary retains its skeleton, with no navigation overlap or browser errors.

## Notes

- `prefetch={false}` is intentional on the demo entry point so the first route transition visibly exercises the top loader.
- The top loader covers route navigation; the Suspense fallbacks cover server work that continues after the route shell arrives.
