### PR TITLE
Improve commit quality controls

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -1,8 +1,7 @@
 module.exports = {
   types: [
     { value: "feat", name: "feat:     A new feature" },
-    { value: "fix", name: "fix:      An enhancement or adjustment" },
-    { value: "bugfix", name: "bugfix:   A bug fix" },
+    { value: "fix", name: "fix:      A bug fix" },
     { value: "docs", name: "docs:     Documentation only changes" },
     {
       value: "style",
@@ -21,15 +20,17 @@ module.exports = {
       value: "chore",
       name: "chore:    Changes to the build process or auxiliary tools\n            and libraries such as documentation generation",
     },
+    { value: "build", name: "build:    Changes to the build system" },
+    { value: "ci", name: "ci:       Changes to CI configuration" },
     { value: "revert", name: "revert:   Revert to a commit" },
-    { value: "WIP", name: "WIP:      Work in progress" },
   ],
 
   scopes: [
     { name: "web" },
-    { name: "api" },
+    { name: "ui" },
+    { name: "constants" },
+    { name: "types" },
     { name: "workflows" },
-    { name: "packages" },
     { name: "scripts" },
     { name: "docs" },
   ],
@@ -56,9 +57,8 @@ module.exports = {
   messages: {
     type: "Select the type of change that you're committing:",
     scope: "\nDenote the SCOPE of this change (optional):",
-    // used if allowCustomScopes is true
-    customScope: "Denote the SCOPE of this change:",
-    subject: "Write a SHORT, IMPERATIVE tense description of the change:\n",
+    subject:
+      "Write a SHORT, lowercase, IMPERATIVE description of the change:\n",
     body: 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n',
     breaking: "List any BREAKING CHANGES (optional):\n",
     footer:
@@ -66,10 +66,8 @@ module.exports = {
     confirmCommit: "Are you sure you want to proceed with the commit above?",
   },
 
-  allowCustomScopes: true,
-  allowBreakingChanges: ["feat", "fix", "bugfix"],
-  // skip any questions you want
-  skipQuestions: ["body"],
+  allowCustomScopes: false,
+  allowBreakingChanges: ["feat", "fix"],
 
   // limit subject length
   subjectLimit: 50,

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Describe the changes in the following format:
   - Detailed change 1
   - Detailed change 2
 
-- ### Improvement or bugfix of YY feature
+- ### Improvement or bug fix of YY feature
   - Explanation of the change
   - Effect of the change
 -->

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,12 +56,12 @@ autolabeler:
   # Automatically applies the "⚒️enhancement" label based on branch naming patterns.
   - label: "⚒️enhancement"
     branch:
-      - "/^(fix|enhance|improve|refactor|enhancement)[/-].+/"
+      - "/^(enhance|improve|refactor|enhancement)[/-].+/"
 
   # Automatically applies the "🐛bug" label based on branch naming patterns.
   - label: "🐛bug"
     branch:
-      - "/^bugfix[/-].+/"
+      - "/^fix[/-].+/"
 
   # Automatically applies the "📝documentation" label based on branch naming patterns or file changes.
   - label: "📝documentation"

--- a/.github/workflows/assign-labels.yml
+++ b/.github/workflows/assign-labels.yml
@@ -27,8 +27,6 @@ jobs:
           elif [ $branch_type == 'docs' ]; then
             label_name="📝documentation"
           elif [ $branch_type == 'fix' ]; then
-            label_name="⚒️enhancement"
-          elif [ $branch_type == 'bugfix' ]; then
             label_name="🐛bug"
           elif [ $branch_type == 'hotfix' ]; then
             label_name="🐞hotfix"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,23 +5,31 @@ on:
     branches: [main, develop]
     paths:
       - ".github/workflows/tests.yml"
+      - ".cz-config.js"
+      - ".husky/**"
       - "apps/**"
+      - "commitlint.config.js"
       - "package.json"
       - "package-scripts.js"
       - "packages/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "scripts/**"
       - "turbo.json"
   pull_request:
     branches: [main, develop]
     paths:
       - ".github/workflows/tests.yml"
+      - ".cz-config.js"
+      - ".husky/**"
       - "apps/**"
+      - "commitlint.config.js"
       - "package.json"
       - "package-scripts.js"
       - "packages/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "scripts/**"
       - "turbo.json"
   workflow_dispatch:
 
@@ -34,6 +42,18 @@ env:
   COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
 
 jobs:
+  script-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+          package-manager-cache: false
+      - name: Test repository scripts
+        run: npx nps test.ci.scripts
+
   changes:
     runs-on: ubuntu-latest
     outputs:

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+node scripts/check-commit-size.mjs --cached

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
     "body-max-line-length": [2, "always", 100],
     "footer-leading-blank": [1, "always"],
     "footer-max-line-length": [2, "always", 100],
-    "header-max-length": [2, "always", 100],
+    "header-max-length": [2, "always", 72],
     "header-trim": [2, "always"],
     "subject-case": [
       2,
@@ -14,6 +14,7 @@ module.exports = {
     ],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
+    "subject-max-length": [2, "always", 50],
     "type-case": [2, "always", "lower-case"],
     "type-empty": [2, "never"],
     "type-enum": [
@@ -26,7 +27,6 @@ module.exports = {
         "docs",
         "feat",
         "fix",
-        "bugfix",
         "perf",
         "refactor",
         "revert",

--- a/docs/github-actions/assign-labels.md
+++ b/docs/github-actions/assign-labels.md
@@ -6,8 +6,7 @@
 
 - Pull request must be **opened** (not updated/reopened)
 - Branch must follow naming convention: `{type}/{description}`
-- Supported branch types: `feat`, `enhance`, `docs`, `fix`, `bugfix`,
-  `hotfix`
+- Supported branch types: `feat`, `enhance`, `docs`, `fix`, `hotfix`
 - Corresponding labels must exist in the repository
 
 ## How It Works
@@ -20,8 +19,7 @@ type (first segment before `/`):
 | `feat/`     | 🌱feature       |
 | `enhance/`  | ⚒️enhancement   |
 | `docs/`     | 📝documentation |
-| `fix/`      | ⚒️enhancement   |
-| `bugfix/`   | 🐛bug           |
+| `fix/`      | 🐛bug           |
 | `hotfix/`   | 🐞hotfix        |
 
 ### Process

--- a/docs/github-actions/release-drafter.md
+++ b/docs/github-actions/release-drafter.md
@@ -61,8 +61,8 @@ Version bumps are determined by labels on pull requests:
 Labels are automatically applied based on branch naming patterns or file
 changes:
 
-1. **Enhancement**: Branch name starts with `fix/`, `enhance/`, `improve/`,
+1. **Enhancement**: Branch name starts with `enhance/`, `improve/`,
    `refactor/`, or `enhancement/`
-2. **Bug Fix**: Branch name starts with `bugfix/`
+2. **Bug Fix**: Branch name starts with `fix/`
 3. **Documentation**: Branch name starts with `doc/`, `document/`, or
    `documentation/` OR changes `.md` files

--- a/docs/instructions/github-workflows/TASK.md
+++ b/docs/instructions/github-workflows/TASK.md
@@ -15,7 +15,7 @@ On Issue:
 - Create PR with "Closes #{issue_number}"
 
 **BRANCH NAMING**: Use format: <type>/<description> Valid types: feat, fix,
-bugfix, hotfix, docs, enhance, improve, refactor
+hotfix, docs, enhance, improve, refactor
 
 **COMMIT MESSAGES**: Follow Conventional Commits:
 
@@ -27,9 +27,9 @@ bugfix, hotfix, docs, enhance, improve, refactor
 <footer>
 ```
 
-- Types: feat, fix, bugfix, docs, style, refactor, perf, test, build, ci,
+- Types: feat, fix, docs, style, refactor, perf, test, build, ci,
   chore, revert
-- Subject: Use imperative mood (add, fix, refactor), keep concise
+- Subject: Use lowercase imperative mood (add, fix, refactor), keep concise
 - Body: Explain why and what changed
 - Footer: Reference issues (Closes #123, Fixes #456)
 
@@ -42,7 +42,7 @@ bugfix, hotfix, docs, enhance, improve, refactor
 **PR DESCRIPTION**: Include:
 
 - Overview: What this PR does
-- Changes: Detailed changes organized by feature/improvement/bugfix
+- Changes: Detailed changes organized by feature/improvement/bug fix
 - Impact Scope: UI, Database, API, Configuration, Environment variables, Code
   cleanup
 - Notes: Implementation concerns or additional tasks
@@ -64,7 +64,7 @@ For feature implementation:
 
 For bug fixes:
 
-- `bugfix: resolve navigation router issue` (core bug fix)
+- `fix: resolve navigation router issue` (core bug fix)
 - `test: add navigation regression tests` (prevention)
 
 **GUIDELINES**:

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -45,10 +45,12 @@ module.exports = {
       },
     },
     test: {
-      default: `nps test.web`,
+      default: `nps test.scripts && nps test.web`,
+      scripts: `node --test scripts/tests/*.test.mjs`,
       web: `cd ${webPath} && pnpm test`,
       ci: {
-        default: `nps test.ci.web`,
+        default: `nps test.ci.scripts && nps test.ci.web`,
+        scripts: `node --test scripts/tests/*.test.mjs`,
         web: `cd ${ciWebPath} && pnpm test:ci`,
       },
       watch: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "turbo run build",
     "commit": "cz",
-    "postinstall": "node -e \"const f='scripts/link-agent-skills.mjs';if(require('fs').existsSync(f))require('child_process').execFileSync(process.execPath,[f],{stdio:'inherit'})\""
+    "postinstall": "node -e \"const f='scripts/link-agent-skills.mjs';if(require('fs').existsSync(f))require('child_process').execFileSync(process.execPath,[f],{stdio:'inherit'})\"",
+    "prepare": "node -e \"const f='scripts/install-husky.mjs';if(require('fs').existsSync(f))require('child_process').execFileSync(process.execPath,[f],{stdio:'inherit'})\""
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",

--- a/scripts/check-commit-size.mjs
+++ b/scripts/check-commit-size.mjs
@@ -1,0 +1,94 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const DEFAULT_MAX_CHANGED_LINES = 500;
+export const DEFAULT_EXCLUDED_PATHS = new Set(["pnpm-lock.yaml"]);
+
+export function countChangedLines(
+  numstat,
+  excludedPaths = DEFAULT_EXCLUDED_PATHS,
+) {
+  let changedLines = 0;
+
+  for (const line of numstat.split("\n")) {
+    if (!line) continue;
+
+    const [additions, deletions, path] = line.split("\t");
+
+    if (path === undefined) {
+      throw new Error(`Unexpected git numstat line: ${line}`);
+    }
+
+    if (excludedPaths.has(path)) continue;
+    if (additions === "-" && deletions === "-") continue;
+
+    const additionCount = Number.parseInt(additions, 10);
+    const deletionCount = Number.parseInt(deletions, 10);
+
+    if (!Number.isInteger(additionCount) || !Number.isInteger(deletionCount)) {
+      throw new Error(`Unexpected git numstat line: ${line}`);
+    }
+
+    changedLines += additionCount + deletionCount;
+  }
+
+  return changedLines;
+}
+
+export function evaluateCommitSize(
+  numstat,
+  maxChangedLines = DEFAULT_MAX_CHANGED_LINES,
+) {
+  const changedLines = countChangedLines(numstat);
+
+  return {
+    changedLines,
+    maxChangedLines,
+    passes: changedLines <= maxChangedLines,
+  };
+}
+
+export function parseMaxChangedLines(value) {
+  if (value === undefined) return DEFAULT_MAX_CHANGED_LINES;
+
+  const maxChangedLines = Number(value);
+
+  if (!Number.isInteger(maxChangedLines) || maxChangedLines < 1) {
+    throw new Error("MAX_COMMIT_CHANGED_LINES must be a positive integer.");
+  }
+
+  return maxChangedLines;
+}
+
+function main() {
+  if (process.argv.length !== 3 || process.argv[2] !== "--cached") {
+    console.error("Usage: node scripts/check-commit-size.mjs --cached");
+    process.exitCode = 2;
+    return;
+  }
+
+  const numstat = execFileSync(
+    "git",
+    ["diff", "--cached", "--numstat", "--no-renames"],
+    { encoding: "utf8" },
+  );
+  const result = evaluateCommitSize(
+    numstat,
+    parseMaxChangedLines(process.env.MAX_COMMIT_CHANGED_LINES),
+  );
+
+  if (result.passes) return;
+
+  console.error(
+    [
+      `Commit contains ${result.changedLines} reviewable changed lines; the limit is ${result.maxChangedLines}.`,
+      "Split the staged changes into smaller, focused commits.",
+      "Use --no-verify only when the repository policy explicitly permits an exception.",
+    ].join("\n"),
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/install-husky.mjs
+++ b/scripts/install-husky.mjs
@@ -1,0 +1,23 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+if (
+  process.env.CI ||
+  process.env.HUSKY === "0" ||
+  process.env.NODE_ENV === "production" ||
+  !existsSync(join(repoRoot, ".git"))
+) {
+  process.exit(0);
+}
+
+process.chdir(repoRoot);
+
+const husky = (await import("husky")).default;
+const message = husky();
+
+if (message) {
+  throw new Error(message);
+}

--- a/scripts/tests/check-commit-size.test.mjs
+++ b/scripts/tests/check-commit-size.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  countChangedLines,
+  evaluateCommitSize,
+  parseMaxChangedLines,
+} from "../check-commit-size.mjs";
+
+describe("countChangedLines", () => {
+  it("counts additions and deletions", () => {
+    const numstat = "12\t3\tsrc/example.ts\n4\t1\tsrc/other.ts\n";
+
+    assert.equal(countChangedLines(numstat), 20);
+  });
+
+  it("excludes the generated pnpm lockfile", () => {
+    const numstat = "600\t200\tpnpm-lock.yaml\n20\t5\tpackage.json\n";
+
+    assert.equal(countChangedLines(numstat), 25);
+  });
+
+  it("does not count binary files as reviewable lines", () => {
+    assert.equal(countChangedLines("-\t-\tpublic/image.png\n"), 0);
+  });
+
+  it("fails closed for malformed numstat output", () => {
+    assert.throws(
+      () => countChangedLines("not-numstat\n"),
+      /Unexpected git numstat line/,
+    );
+  });
+});
+
+describe("evaluateCommitSize", () => {
+  it("allows exactly 500 changed lines", () => {
+    assert.deepEqual(evaluateCommitSize("300\t200\tsrc/example.ts\n"), {
+      changedLines: 500,
+      maxChangedLines: 500,
+      passes: true,
+    });
+  });
+
+  it("rejects 501 changed lines", () => {
+    assert.deepEqual(evaluateCommitSize("301\t200\tsrc/example.ts\n"), {
+      changedLines: 501,
+      maxChangedLines: 500,
+      passes: false,
+    });
+  });
+});
+
+describe("parseMaxChangedLines", () => {
+  it("uses 500 by default", () => {
+    assert.equal(parseMaxChangedLines(undefined), 500);
+  });
+
+  it("accepts a positive integer", () => {
+    assert.equal(parseMaxChangedLines("750"), 750);
+  });
+
+  it("rejects partial and fractional numbers", () => {
+    assert.throws(
+      () => parseMaxChangedLines("500abc"),
+      /must be a positive integer/,
+    );
+    assert.throws(
+      () => parseMaxChangedLines("500.5"),
+      /must be a positive integer/,
+    );
+  });
+});


### PR DESCRIPTION
## Overview

Standardize the repository's commit conventions and add a local guard against oversized commits. This establishes the foundation for the required PR quality check planned for the next phase.

## Changes

### Standardize commit conventions

- Use the Conventional Commits meaning of `fix` for bug fixes.
- Remove the conflicting `bugfix` and `WIP` types.
- Align Commitizen, commitlint, branch labels, Release Drafter, and workflow documentation.
- Enforce a 50-character subject and a 72-character header.

### Enforce local commit size

- Install Husky automatically for local clones while safely skipping CI and production installs.
- Reject staged commits containing more than 500 reviewable changed lines.
- Exclude the generated `pnpm-lock.yaml` from the line count.
- Run repository script tests locally and in GitHub Actions.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

- `nps lint`
- `nps typecheck`
- `nps test`
- `nps build`
- `CI=1 nps prepare.web`
- `nps docker.build.web`

## Screenshots

Not applicable.

## Notes

The local hook provides early feedback and remains bypassable with `--no-verify`. A required PR quality check and its exception-label workflow are intentionally deferred to the next phase.
