### PR TITLE
Add GitHub repository setup automation

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -14,7 +14,7 @@
 - name: "📝documentation"
   description: "Documentation improvement or addition"
   color: "0075CA"
-- name: "💬quesion"
+- name: "💬question"
   description: "General inquiries or clarifications"
   color: "D876E3"
 - name: "🔁duplicate"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -53,19 +53,29 @@ template: |
   $CHANGES
 
 autolabeler:
+  # Automatically applies the "🌱feature" label based on branch naming patterns.
+  - label: "🌱feature"
+    branch:
+      - "/^feat[/-].+/"
+
   # Automatically applies the "⚒️enhancement" label based on branch naming patterns.
   - label: "⚒️enhancement"
     branch:
-      - "/^(enhance|improve|refactor|enhancement)[/-].+/"
+      - "/^(enhance|improve|refactor)[/-].+/"
 
   # Automatically applies the "🐛bug" label based on branch naming patterns.
   - label: "🐛bug"
     branch:
       - "/^fix[/-].+/"
 
+  # Automatically applies the "🐞hotfix" label based on branch naming patterns.
+  - label: "🐞hotfix"
+    branch:
+      - "/^hotfix[/-].+/"
+
   # Automatically applies the "📝documentation" label based on branch naming patterns or file changes.
   - label: "📝documentation"
     branch:
-      - "/^(doc|document|documentation)[/-].+/"
+      - "/^docs[/-].+/"
     files:
       - "*.md"

--- a/.github/workflows/assign-labels.yml
+++ b/.github/workflows/assign-labels.yml
@@ -13,29 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BRANCH_TYPE: ${{ github.head_ref }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REPOSITORY: ${{ github.repository }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
       - name: Get label name
         id: label_name
         run: |
-          branch_type=$(echo ${{ github.head_ref }} | cut -d "/" -f1)
-          if [ $branch_type == 'feat' ]; then
-            label_name="🌱feature"
-          elif [ $branch_type == 'enhance' ]; then
-            label_name="⚒️enhancement"
-          elif [ $branch_type == 'docs' ]; then
-            label_name="📝documentation"
-          elif [ $branch_type == 'fix' ]; then
-            label_name="🐛bug"
-          elif [ $branch_type == 'hotfix' ]; then
-            label_name="🐞hotfix"
-          else
-            label_name=""
-          fi
-          echo "label_name=$label_name" >> $GITHUB_OUTPUT
+          case "${BRANCH_TYPE%%/*}" in
+            feat) label_name="🌱feature" ;;
+            enhance|improve|refactor) label_name="⚒️enhancement" ;;
+            docs) label_name="📝documentation" ;;
+            fix) label_name="🐛bug" ;;
+            hotfix) label_name="🐞hotfix" ;;
+            *) label_name="" ;;
+          esac
+          echo "label_name=$label_name" >> "$GITHUB_OUTPUT"
       - name: Auto labeling
         if: ${{ steps.label_name.outputs.label_name != '' }}
-        run: |
-          number=$(echo ${{ github.event.pull_request.number }})
-          gh pr edit $number --add-label ${{ steps.label_name.outputs.label_name }}
+        env:
+          LABEL_NAME: ${{ steps.label_name.outputs.label_name }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" --add-label "$LABEL_NAME"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,6 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Migrate renamed labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          legacy_exists=false
+          corrected_exists=false
+          gh label view "💬quesion" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && legacy_exists=true
+          gh label view "💬question" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && corrected_exists=true
+
+          if [[ "$legacy_exists" == "true" && "$corrected_exists" == "true" ]]; then
+            echo "Both question labels exist. Merge their assignments before syncing." >&2
+            exit 1
+          fi
+
+          if [[ "$legacy_exists" == "true" ]]; then
+            gh label edit "💬quesion" --repo "$GITHUB_REPOSITORY" --name "💬question"
+          fi
       - name: Sync labels
         uses: micnncim/action-label-syncer@v1
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     paths:
       - ".github/workflows/tests.yml"
       - ".cz-config.js"
@@ -17,20 +17,7 @@ on:
       - "scripts/**"
       - "turbo.json"
   pull_request:
-    branches: [main, develop]
-    paths:
-      - ".github/workflows/tests.yml"
-      - ".cz-config.js"
-      - ".husky/**"
-      - "apps/**"
-      - "commitlint.config.js"
-      - "package.json"
-      - "package-scripts.js"
-      - "packages/**"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "scripts/**"
-      - "turbo.json"
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -57,11 +44,12 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      web: ${{ steps.filter.outputs.web }}
+      web: ${{ steps.force.outputs.web || steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name != 'workflow_dispatch'
         with:
           filters: |
             web:
@@ -72,7 +60,12 @@ jobs:
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - 'scripts/**'
               - 'turbo.json'
+      - name: Run all checks for manual dispatch
+        id: force
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "web=true" >> "$GITHUB_OUTPUT"
 
   setup:
     runs-on: ubuntu-latest
@@ -150,3 +143,25 @@ jobs:
       - name: Test
         if: matrix.run == 'true'
         run: npx nps test.ci.${{ matrix.target }}
+
+  required-checks:
+    name: Required checks
+    if: always()
+    needs: [script-tests, changes, setup, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs
+        env:
+          SCRIPT_TESTS_RESULT: ${{ needs.script-tests.result }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          WEB_CHANGED: ${{ needs.changes.outputs.web }}
+          SETUP_RESULT: ${{ needs.setup.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$SCRIPT_TESTS_RESULT" != "success" || "$CHANGES_RESULT" != "success" ]]; then
+            exit 1
+          fi
+
+          if [[ "$WEB_CHANGED" == "true" && ( "$SETUP_RESULT" != "success" || "$TEST_RESULT" != "success" ) ]]; then
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ turborepo-starter/
 
 - Node.js 24.0 or higher
 - pnpm 11.5.3 or higher (via Corepack)
+- GitHub CLI (`gh`), authenticated as a repository administrator
 
 ### Installation
 
@@ -94,7 +95,20 @@ pnpm install
 pnpm add -g nps
 ```
 
-3. **Configure local environment**
+3. **Configure GitHub**
+
+Preview and apply the starter's repository settings, Actions permissions,
+labels, and `main` protection:
+
+```sh
+nps "setup.github --dry-run --defaults"
+nps setup.github
+```
+
+See [GitHub Repository Setup](docs/github-actions/setup-github.md) for
+non-interactive setup and secret management.
+
+4. **Configure local environment**
 
 Copy the example env file and fill in the values you need for local
 development:
@@ -103,7 +117,7 @@ development:
 cp apps/web/.env.example apps/web/.env   # BASE_URL, LOG_LEVEL (optional)
 ```
 
-4. **Run Development Server**
+5. **Run Development Server**
 
 ```sh
 nps dev
@@ -123,7 +137,7 @@ The web app reads runtime configuration from `apps/web/.env`. See
 
 ### GitHub Actions Variables
 
-Set the following variables in your GitHub repository settings under
+Configure these optional variables through `nps setup.github` or under
 **Settings > Secrets and variables > Variables**:
 
 | Variable             | Default                    |
@@ -136,8 +150,9 @@ Set the following variables in your GitHub repository settings under
 
 ### GitHub Actions Secrets
 
-For GitHub Copilot authentication, add the following secret under **Settings >
-Secrets and variables > Secrets**:
+For GitHub Copilot authentication, run `nps setup.github.secrets` or add the
+following Repository secrets under **Settings > Secrets and variables >
+Secrets**:
 
 | Secret                  | Default |
 | ----------------------- | ------- |
@@ -163,8 +178,10 @@ list.
 | `nps lint.web`       | Lint only the web app                        |
 | `nps format`         | Format all apps and packages                 |
 | `nps typecheck`      | Type-check all apps and packages             |
-| `nps test`           | Run web app tests                            |
+| `nps test`           | Run repository script and web app tests      |
 | `nps test.watch`     | Run web app tests in watch mode              |
+| `nps setup.github`   | Configure GitHub repository settings         |
+| `nps setup.github.secrets` | Configure Repository or Environment secrets |
 | `nps docker.build.web` | Build the web Docker image                  |
 | `nps docker.start.web` | Start the web container via docker-compose  |
 | `nps start`          | Start the built web app in production mode   |
@@ -185,7 +202,7 @@ project standards.
 | **Sync Labels**     | Manual dispatch         | Synchronizes repository labels with `.github/labels.yml` configuration |
 | **Display Details** | Manual dispatch         | Displays project, apps, and repository information                     |
 | **Release Drafter** | Push/PR to main         | Creates and updates draft releases with categorized changes            |
-| **Tests**           | Push/PR to main/develop | Runs tests for affected apps and packages                              |
+| **Tests**           | Push/PR to main         | Runs tests for affected apps and packages                              |
 | **Run AI Agent**    | Issue/PR comment        | Executes AI-powered code tasks via `/oc` or `/opencode` commands       |
 
 ### Documentation

--- a/docs/github-actions/assign-labels.md
+++ b/docs/github-actions/assign-labels.md
@@ -6,7 +6,8 @@
 
 - Pull request must be **opened** (not updated/reopened)
 - Branch must follow naming convention: `{type}/{description}`
-- Supported branch types: `feat`, `enhance`, `docs`, `fix`, `hotfix`
+- Supported branch types: `feat`, `enhance`, `improve`, `refactor`, `docs`,
+  `fix`, `hotfix`
 - Corresponding labels must exist in the repository
 
 ## How It Works
@@ -18,6 +19,8 @@ type (first segment before `/`):
 | ----------- | --------------- |
 | `feat/`     | 🌱feature       |
 | `enhance/`  | ⚒️enhancement   |
+| `improve/`  | ⚒️enhancement   |
+| `refactor/` | ⚒️enhancement   |
 | `docs/`     | 📝documentation |
 | `fix/`      | 🐛bug           |
 | `hotfix/`   | 🐞hotfix        |

--- a/docs/github-actions/release-drafter.md
+++ b/docs/github-actions/release-drafter.md
@@ -61,8 +61,9 @@ Version bumps are determined by labels on pull requests:
 Labels are automatically applied based on branch naming patterns or file
 changes:
 
-1. **Enhancement**: Branch name starts with `enhance/`, `improve/`,
-   `refactor/`, or `enhancement/`
-2. **Bug Fix**: Branch name starts with `fix/`
-3. **Documentation**: Branch name starts with `doc/`, `document/`, or
-   `documentation/` OR changes `.md` files
+1. **Feature**: Branch name starts with `feat/`
+2. **Enhancement**: Branch name starts with `enhance/`, `improve/`, or
+   `refactor/`
+3. **Bug Fix**: Branch name starts with `fix/`
+4. **Hotfix**: Branch name starts with `hotfix/`
+5. **Documentation**: Branch name starts with `docs/` or changes `.md` files

--- a/docs/github-actions/setup-github.md
+++ b/docs/github-actions/setup-github.md
@@ -1,0 +1,104 @@
+# GitHub Repository Setup
+
+**Command**: `nps setup.github`
+
+## Prerequisites
+
+- The repository has a `main` branch containing this starter
+- [GitHub CLI](https://cli.github.com/) is installed and authenticated
+- The authenticated account has repository administrator permission
+- Organization policies allow repository-level Actions and Ruleset changes
+
+## Interactive Setup
+
+Run the setup wizard:
+
+```sh
+nps setup.github
+```
+
+The wizard reads the current GitHub configuration, asks for optional metadata
+and AI variables, and displays every planned change before confirmation. A
+cancelled run does not apply changes.
+
+The setup manages:
+
+- Repository features and merge methods
+- Default commit title and body formats
+- GitHub Actions permissions and selected-action allowlist
+- Labels from `.github/labels.yml`
+- A `Starter: protect main` Ruleset
+- Optional repository description, homepage, topics, and AI variables
+
+## Dry Run and Defaults
+
+NPS requires the script and its arguments to be enclosed in quotes:
+
+```sh
+nps "setup.github --dry-run --defaults"
+nps "setup.github --defaults --yes"
+```
+
+`--defaults` skips optional metadata and AI variable prompts. `--yes` skips the
+final confirmation. Use `--repo owner/repository` to target a repository other
+than the current Git remote.
+
+Label synchronization prunes labels not declared in `.github/labels.yml`. The
+dry run lists every label that would be created, updated, renamed, or deleted.
+
+## Main Protection
+
+The managed Ruleset requires pull requests and a successful `Required checks`
+job against the latest `main`. It blocks branch deletion and force pushes while
+allowing repository administrators to bypass the Ruleset.
+
+Setup dispatches and waits for the Tests workflow before creating the Ruleset.
+If Repository Rulesets are unavailable, setup applies equivalent classic branch
+protection without weakening stricter existing protection.
+
+## Actions Permissions
+
+Setup enables Actions with a read-only default `GITHUB_TOKEN` and permits only
+GitHub-owned actions plus the third-party actions used by this starter. It does
+not enable Actions to create or approve pull requests.
+
+If an existing repository requires actions to be pinned to full commit SHAs,
+setup preserves that requirement and stops before applying changes because the
+starter currently uses tag references.
+
+## Secrets
+
+Configure Copilot credentials as Repository secrets:
+
+```sh
+nps setup.github.secrets
+```
+
+Configure a custom Repository or Environment secret:
+
+```sh
+nps "setup.github.secrets --scope repository --name API_TOKEN"
+nps "setup.github.secrets --environment production --name DATABASE_URL"
+```
+
+The command lists existing secret names but cannot read their values. Secret
+values are entered directly through `gh secret set`; the Node.js setup process
+does not receive or log them.
+
+Existing Environments are offered as choices. A new Environment can be created
+after confirmation. Environment protection rules such as reviewers, deployment
+branches, and wait timers are outside this command's scope.
+
+Jobs must declare an Environment to access its secrets:
+
+```yaml
+jobs:
+  deploy:
+    environment: production
+```
+
+## Known Limitation
+
+The existing `/oc task` workflow mode requests a read-only contents token, so it
+cannot push a branch or create a pull request. Repository setup intentionally
+does not broaden that workflow permission.

--- a/docs/github-actions/sync-labels.md
+++ b/docs/github-actions/sync-labels.md
@@ -36,12 +36,12 @@ The workflow manages all labels defined in `.github/labels.yml`:
 
 - **Types**: `🌱feature`, `⚒️enhancement`, `🐛bug`, `🐞hotfix`,
   `📝documentation`
-- **Questions/Issues**: `💬quesion`, `🔁duplicate`, `🚫wontfix`
+- **Questions/Issues**: `💬question`, `🔁duplicate`, `🚫wontfix`
 - **Version**: `🌟major`
 - **Apps**: `🌐app: web`
-- **Packages**: `📦package: jest`, `📦package: vitest`, `📦package: eslint`,
+- **Packages**: `📦package: vitest`, `📦package: eslint`,
   `📦package: prettier`, `📦package: tsconfig`, `📦package: ui`,
   `📦package: types`, `📦package: constants`
 - **Workflows**: `🔄workflow: sync-labels`, `🔄workflow: release`,
-  `🔄workflow: deployment`, `🔄workflow: get-details`,
+  `🔄workflow: get-details`,
   `🔄workflow: display-details`, `🔄workflow: tests`

--- a/docs/github-actions/tests.md
+++ b/docs/github-actions/tests.md
@@ -4,47 +4,50 @@
 
 ## Prerequisites
 
-- Push to `main` or `develop` branches with application, package, workflow, or
-  root toolchain changes
-- Pull request against `main` or `develop` branches with the same relevant
-  changes
+- Push to `main` with application, package, workflow, or root toolchain changes
+- Pull request against `main`
 - Or manual trigger via GitHub Actions UI (`workflow_dispatch`)
 - Node.js 24.x compatible environment
 - pnpm 11.5.3 managed by Corepack with a lockfile present
 
 ## How It Works
 
-The workflow automatically runs tests for applications and packages when
-relevant changes are detected. It uses path filtering to optimize test execution
-by only running tests when specific directories change.
+The workflow always reports a `Required checks` result for pull requests while
+using path filtering to skip expensive application checks when no relevant files
+changed.
 
 ### Process
 
-1. **Trigger**: Push/PR to `main`/`develop` or manual dispatch
+1. **Trigger**: Push/PR to `main` or manual dispatch
 2. **Filter**: Detect application, package, workflow, and root toolchain changes
 3. **Setup**: Install Node.js 24.x, cache dependencies, lint, and typecheck
 4. **Prepare**: Prune monorepo and install dependencies (CI mode)
 5. **Build**: Build the application
 6. **Test**: Run test suite
+7. **Required checks**: Aggregate required jobs into one Ruleset-compatible result
 
 ### Job Structure
 
-| Job     | Purpose                               | Conditions               |
-| ------- | ------------------------------------- | ------------------------ |
-| changes | Detect file changes in relevant paths | Always runs              |
-| setup   | Install, lint, and typecheck           | Runs if changes detected |
-| test    | Build and test the application        | Runs if setup succeeds   |
+| Job             | Purpose                                   | Conditions               |
+| --------------- | ----------------------------------------- | ------------------------ |
+| script-tests    | Test repository automation scripts        | Always runs              |
+| changes         | Detect file changes in relevant paths     | Always runs              |
+| setup           | Install, lint, and typecheck              | Runs if changes detected |
+| test            | Build and test the application            | Runs if setup succeeds   |
+| Required checks | Aggregate the required results for `main` | Always runs              |
 
 ### Change Detection
 
 The workflow uses [dorny/paths-filter](https://github.com/dorny/paths-filter) to
 detect changes:
 
-| Target | Paths Monitored                                                         |
-| ------ | ----------------------------------------------------------------------- |
-| web    | `apps/web/**`, `packages/**`, the tests workflow, and root toolchain files |
+| Target | Paths Monitored                                                                          |
+| ------ | ---------------------------------------------------------------------------------------- |
+| web    | `apps/web/**`, `packages/**`, `scripts/**`, the tests workflow, and root toolchain files |
 
 Tests only run for a target if changes are detected in its monitored paths.
+Manual dispatches run all targets so repository setup can verify the required
+status check before protecting `main`.
 
 ### Commands Executed
 

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -7,6 +7,12 @@ const ciWebPath = path.resolve(__dirname, "out/apps/web");
 module.exports = {
   scripts: {
     link: `node scripts/link-agent-skills.mjs`,
+    setup: {
+      github: {
+        default: `node scripts/setup/github/repository.mts`,
+        secrets: `node scripts/setup/github/secrets.mts`,
+      },
+    },
     prepare: {
       default: `nps prepare.web`,
       web: `pnpm install`,
@@ -35,7 +41,8 @@ module.exports = {
       },
     },
     typecheck: {
-      default: `npx turbo run typecheck`,
+      default: `nps typecheck.scripts && npx turbo run typecheck`,
+      scripts: `pnpm exec tsc6 --project scripts/tsconfig.json`,
       web: `npx turbo run typecheck --filter=web`,
       packages: {
         default: `npx turbo run typecheck --filter=@workspace/ui --filter=@workspace/constants --filter=@workspace/types`,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
+    "@types/node": "^24.13.2",
     "@typescript/native": "npm:typescript@7.0.2",
     "commitizen": "^4.3.1",
     "cz-conventional-changelog": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.6.0
         version: 19.8.1
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
       '@typescript/native':
         specifier: npm:typescript@7.0.2
         version: typescript@7.0.2

--- a/scripts/setup/github/lib.mts
+++ b/scripts/setup/github/lib.mts
@@ -1,0 +1,138 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CommandErrorFields {
+  command: string;
+  status: number | null | undefined;
+  stderr: string;
+  httpStatus: number;
+}
+
+export type ApiMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface RunCommandOptions {
+  inherit?: boolean | undefined;
+  input?: string | undefined;
+}
+
+export interface RepositoryPermissions {
+  admin?: boolean;
+}
+
+export interface RepositoryRestState {
+  full_name: string;
+  description?: string | null;
+  homepage?: string | null;
+  permissions?: RepositoryPermissions;
+  [key: string]: unknown;
+}
+
+export interface PreflightResult {
+  repository: string;
+  state: RepositoryRestState;
+}
+
+export const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+export class CommandError extends Error implements CommandErrorFields {
+  command: string;
+  status: number | null | undefined;
+  stderr: string;
+  httpStatus: number;
+
+  constructor(command: string, error: unknown) {
+    const details =
+      typeof error === "object" && error !== null
+        ? (error as Record<string, unknown>)
+        : {};
+    const stderr = String(details.stderr ?? "").trim();
+    super(stderr || `${command} failed.`);
+    this.name = "CommandError";
+    this.command = command;
+    this.status = details.status as number | null | undefined;
+    this.stderr = stderr;
+    this.httpStatus = Number(stderr.match(/HTTP (\d{3})/)?.[1]);
+  }
+}
+
+export function runCommand(
+  command: string,
+  args: string[],
+  options: RunCommandOptions & { inherit: true },
+): void;
+export function runCommand(
+  command: string,
+  args: string[],
+  options?: RunCommandOptions & { inherit?: false | undefined },
+): string;
+export function runCommand(
+  command: string,
+  args: string[],
+  options: RunCommandOptions = {},
+): string | void {
+  try {
+    const output = execFileSync(command, args, {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      stdio: options.inherit ? "inherit" : ["pipe", "pipe", "pipe"],
+      input: options.input,
+    });
+    if (options.inherit) return;
+    return output.trim();
+  } catch (error) {
+    throw new CommandError(`${command} ${args.join(" ")}`, error);
+  }
+}
+
+export function api<T = unknown>(
+  method: ApiMethod,
+  endpoint: string,
+  body?: unknown,
+): T | undefined {
+  const args = ["api", "--method", method, endpoint];
+  if (body !== undefined) args.push("--input", "-");
+  const output = runCommand("gh", args, {
+    input: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return output ? (JSON.parse(output) as T) : undefined;
+}
+
+export function getRepositoryName(explicitRepository?: string): string {
+  if (explicitRepository) return explicitRepository;
+  return runCommand("gh", [
+    "repo",
+    "view",
+    "--json",
+    "nameWithOwner",
+    "--jq",
+    ".nameWithOwner",
+  ]);
+}
+
+export function preflight(explicitRepository?: string): PreflightResult {
+  runCommand("gh", ["--version"]);
+  runCommand("gh", ["auth", "status"]);
+  const repository = getRepositoryName(explicitRepository);
+  const state = api<RepositoryRestState>(
+    "GET",
+    `/repos/${repository}`,
+  ) as RepositoryRestState;
+
+  if (!state.permissions?.admin) {
+    throw new Error(`Admin permission is required for ${repository}.`);
+  }
+
+  try {
+    api("GET", `/repos/${repository}/git/ref/heads/main`);
+  } catch (error) {
+    throw new Error(`${repository} must have a main branch before setup.`, {
+      cause: error,
+    });
+  }
+
+  return { repository, state };
+}

--- a/scripts/setup/github/policy.mts
+++ b/scripts/setup/github/policy.mts
@@ -1,0 +1,592 @@
+export type SetupMode = "setup" | "secrets";
+
+export interface SetupArguments {
+  mode: SetupMode;
+  dryRun: boolean;
+  defaults: boolean;
+  yes: boolean;
+  repository?: string | undefined;
+  scope?: "repository" | undefined;
+  environment?: string | undefined;
+  secretName?: string | undefined;
+}
+
+export interface Label {
+  name: string;
+  description: string;
+  color: string;
+}
+
+export interface CurrentLabel {
+  name: string;
+  description: string | null;
+  color: string;
+}
+
+export interface LabelUpdate {
+  current: CurrentLabel;
+  desired: Label;
+}
+
+export interface LabelDiff {
+  create: Label[];
+  update: LabelUpdate[];
+  remove: CurrentLabel[];
+}
+
+export interface ObjectDiff {
+  key: string;
+  current: unknown;
+  desired: unknown;
+}
+
+export interface RepositoryMetadata {
+  description?: string;
+  homepage?: string;
+}
+
+export interface RepositorySettings extends RepositoryMetadata {
+  default_branch: string;
+  has_issues: boolean;
+  has_projects: boolean;
+  has_wiki: boolean;
+  has_discussions: boolean;
+  allow_merge_commit: boolean;
+  allow_squash_merge: boolean;
+  allow_rebase_merge: boolean;
+  allow_auto_merge: boolean;
+  delete_branch_on_merge: boolean;
+  merge_commit_title: string;
+  merge_commit_message: string;
+  squash_merge_commit_title: string;
+  squash_merge_commit_message: string;
+}
+
+export interface ActionsPermissionsSettings {
+  enabled: boolean;
+  allowed_actions: "selected";
+  sha_pinning_required: boolean;
+}
+
+export interface SelectedActionsSettings {
+  github_owned_allowed: boolean;
+  verified_allowed: boolean;
+  patterns_allowed: string[];
+}
+
+export interface WorkflowSettings {
+  default_workflow_permissions: "read";
+  can_approve_pull_request_reviews: boolean;
+}
+
+export interface ActionsSettings {
+  permissions: ActionsPermissionsSettings;
+  selectedActions: SelectedActionsSettings;
+  workflow: WorkflowSettings;
+}
+
+export interface ActionsPermissionsState {
+  enabled?: boolean;
+  allowed_actions?: string;
+  sha_pinning_required?: boolean;
+}
+
+export interface SelectedActionsState {
+  github_owned_allowed?: boolean;
+  verified_allowed?: boolean;
+  patterns_allowed?: string[];
+}
+
+export interface WorkflowState {
+  default_workflow_permissions?: string;
+  can_approve_pull_request_reviews?: boolean;
+}
+
+export interface ActionsState {
+  permissions: ActionsPermissionsState;
+  selectedActions: SelectedActionsState;
+  workflow: WorkflowState;
+}
+
+export interface RestrictionUser {
+  login?: string;
+}
+
+export interface RestrictionTeam {
+  slug?: string;
+}
+
+export interface RestrictionApp {
+  slug?: string;
+}
+
+export interface RestrictionsInput {
+  users?: Array<string | RestrictionUser>;
+  teams?: Array<string | RestrictionTeam>;
+  apps?: Array<string | RestrictionApp>;
+}
+
+export interface RestrictionsOutput {
+  users: Array<string | RestrictionUser>;
+  teams: Array<string | RestrictionTeam>;
+  apps: Array<string | RestrictionApp>;
+}
+
+export interface BranchStatusCheck {
+  context: string;
+  app_id?: number | null;
+}
+
+export interface BranchProtectionInput {
+  required_status_checks?: {
+    contexts?: string[];
+    checks?: BranchStatusCheck[];
+  };
+  enforce_admins?: { enabled?: boolean };
+  required_pull_request_reviews?: {
+    dismissal_restrictions?: RestrictionsInput | null;
+    dismiss_stale_reviews?: boolean;
+    require_code_owner_reviews?: boolean;
+    required_approving_review_count?: number;
+    require_last_push_approval?: boolean;
+  };
+  restrictions?: RestrictionsInput | null;
+  required_linear_history?: { enabled?: boolean };
+  block_creations?: { enabled?: boolean };
+  lock_branch?: { enabled?: boolean };
+  allow_fork_syncing?: { enabled?: boolean };
+}
+
+export interface BranchProtectionOutput {
+  required_status_checks: {
+    strict: boolean;
+    contexts: string[];
+    checks?: BranchStatusCheck[];
+  };
+  enforce_admins: boolean;
+  required_pull_request_reviews: {
+    dismissal_restrictions?: RestrictionsOutput;
+    dismiss_stale_reviews: boolean;
+    require_code_owner_reviews: boolean;
+    required_approving_review_count: number;
+    require_last_push_approval: boolean;
+  };
+  restrictions: RestrictionsOutput | null;
+  required_conversation_resolution: boolean;
+  required_linear_history: boolean;
+  allow_force_pushes: boolean;
+  allow_deletions: boolean;
+  block_creations: boolean;
+  lock_branch: boolean;
+  allow_fork_syncing: boolean;
+}
+
+export interface RulesetStatusCheck {
+  context: string;
+  integration_id?: number;
+}
+
+export interface RulesetInput {
+  name: string;
+  target: "branch";
+  enforcement: "active";
+  bypass_actors: Array<{
+    actor_id: number;
+    actor_type: "RepositoryRole";
+    bypass_mode: "always";
+  }>;
+  conditions: {
+    ref_name: {
+      include: string[];
+      exclude: string[];
+    };
+  };
+  rules: Array<
+    | { type: "deletion" }
+    | { type: "non_fast_forward" }
+    | {
+        type: "pull_request";
+        parameters: {
+          allowed_merge_methods: Array<"merge" | "squash">;
+          dismiss_stale_reviews_on_push: boolean;
+          require_code_owner_review: boolean;
+          require_last_push_approval: boolean;
+          required_approving_review_count: number;
+          required_review_thread_resolution: boolean;
+        };
+      }
+    | {
+        type: "required_status_checks";
+        parameters: {
+          strict_required_status_checks_policy: boolean;
+          do_not_enforce_on_create: boolean;
+          required_status_checks: RulesetStatusCheck[];
+        };
+      }
+  >;
+}
+
+const REPOSITORY_RULESET_NAME = "Starter: protect main";
+const REQUIRED_CHECK = "Required checks";
+
+export const AI_VARIABLES = [
+  "AI_PROVIDER_ID",
+  "AI_MODEL_ID",
+  "AI_REVIEW_MODEL_ID",
+  "AI_ISSUE_MODEL_ID",
+  "AI_TASK_MODEL_ID",
+];
+export const COPILOT_SECRETS = [
+  "COPILOT_ACCESS_TOKEN",
+  "COPILOT_REFRESH_TOKEN",
+];
+const ALLOWED_ACTION_PATTERNS = [
+  "dorny/paths-filter@*",
+  "release-drafter/release-drafter@*",
+  "micnncim/action-label-syncer@*",
+  "sst/opencode/github@*",
+];
+const LABEL_RENAMES = new Map([["💬quesion", "💬question"]]);
+
+export function parseArguments(argv: string[]): SetupArguments {
+  const args: SetupArguments = {
+    mode: "setup",
+    dryRun: false,
+    defaults: false,
+    yes: false,
+    repository: undefined,
+    scope: undefined,
+    environment: undefined,
+    secretName: undefined,
+  };
+  const values = [...argv];
+
+  if (values[0] === "secrets") {
+    args.mode = values.shift() as "secrets";
+  }
+
+  while (values.length > 0) {
+    const value = values.shift();
+
+    if (value === "--dry-run") args.dryRun = true;
+    else if (value === "--defaults") args.defaults = true;
+    else if (value === "--yes") args.yes = true;
+    else if (value === "--repo") args.repository = requireValue(value, values);
+    else if (value === "--scope")
+      args.scope = requireValue(value, values) as "repository";
+    else if (value === "--environment") {
+      args.environment = requireValue(value, values);
+    } else if (value === "--name") {
+      args.secretName = requireValue(value, values);
+    } else {
+      throw new Error(`Unknown argument: ${value}`);
+    }
+  }
+
+  if (args.scope && args.scope !== "repository") {
+    throw new Error("--scope only accepts 'repository'.");
+  }
+  if (args.scope && args.environment) {
+    throw new Error("Use either --scope or --environment, not both.");
+  }
+  if (
+    args.mode === "setup" &&
+    (args.scope || args.environment || args.secretName)
+  ) {
+    throw new Error("Secret options require the secrets subcommand.");
+  }
+  if (args.mode === "secrets" && args.defaults) {
+    throw new Error("Secrets cannot be configured with --defaults.");
+  }
+  if ((args.scope || args.environment) && !args.secretName) {
+    throw new Error("--scope and --environment require --name.");
+  }
+
+  return args;
+}
+
+function requireValue(flag: string, values: string[]): string {
+  const value = values.shift();
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+export function buildRepositorySettings(
+  metadata: RepositoryMetadata = {},
+): RepositorySettings {
+  return {
+    default_branch: "main",
+    has_issues: true,
+    has_projects: true,
+    has_wiki: false,
+    has_discussions: false,
+    allow_merge_commit: true,
+    allow_squash_merge: true,
+    allow_rebase_merge: false,
+    allow_auto_merge: false,
+    delete_branch_on_merge: true,
+    merge_commit_title: "PR_TITLE",
+    merge_commit_message: "BLANK",
+    squash_merge_commit_title: "PR_TITLE",
+    squash_merge_commit_message: "COMMIT_MESSAGES",
+    ...metadata,
+  };
+}
+
+export function buildActionsSettings({
+  shaPinningRequired = false,
+}: {
+  shaPinningRequired?: boolean;
+} = {}): ActionsSettings {
+  return {
+    permissions: {
+      enabled: true,
+      allowed_actions: "selected",
+      sha_pinning_required: shaPinningRequired,
+    },
+    selectedActions: {
+      github_owned_allowed: true,
+      verified_allowed: false,
+      patterns_allowed: [...ALLOWED_ACTION_PATTERNS],
+    },
+    workflow: {
+      default_workflow_permissions: "read",
+      can_approve_pull_request_reviews: false,
+    },
+  };
+}
+
+export function buildMainRuleset(integrationId: number): RulesetInput {
+  return {
+    name: REPOSITORY_RULESET_NAME,
+    target: "branch",
+    enforcement: "active",
+    bypass_actors: [
+      {
+        actor_id: 5,
+        actor_type: "RepositoryRole",
+        bypass_mode: "always",
+      },
+    ],
+    conditions: {
+      ref_name: {
+        include: ["refs/heads/main"],
+        exclude: [],
+      },
+    },
+    rules: [
+      { type: "deletion" },
+      { type: "non_fast_forward" },
+      {
+        type: "pull_request",
+        parameters: {
+          allowed_merge_methods: ["merge", "squash"],
+          dismiss_stale_reviews_on_push: false,
+          require_code_owner_review: false,
+          require_last_push_approval: false,
+          required_approving_review_count: 0,
+          required_review_thread_resolution: true,
+        },
+      },
+      {
+        type: "required_status_checks",
+        parameters: {
+          strict_required_status_checks_policy: true,
+          do_not_enforce_on_create: false,
+          required_status_checks: [
+            {
+              context: REQUIRED_CHECK,
+              ...(integrationId ? { integration_id: integrationId } : {}),
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+export function buildBranchProtection(
+  current: BranchProtectionInput = {},
+  integrationId: number,
+): BranchProtectionOutput {
+  const contexts = new Set(current.required_status_checks?.contexts ?? []);
+  contexts.add(REQUIRED_CHECK);
+  const checks = new Map(
+    (current.required_status_checks?.checks ?? []).map((check) => [
+      `${check.context}:${check.app_id ?? ""}`,
+      check,
+    ]),
+  );
+  if (integrationId) {
+    checks.set(`${REQUIRED_CHECK}:${integrationId}`, {
+      context: REQUIRED_CHECK,
+      app_id: integrationId,
+    });
+  }
+  const reviews = current.required_pull_request_reviews ?? {};
+  const dismissalRestrictions = mapRestrictions(reviews.dismissal_restrictions);
+
+  return {
+    required_status_checks: {
+      strict: true,
+      contexts: [...contexts],
+      ...(checks.size > 0 ? { checks: [...checks.values()] } : {}),
+    },
+    enforce_admins: Boolean(current.enforce_admins?.enabled),
+    required_pull_request_reviews: {
+      ...(dismissalRestrictions
+        ? { dismissal_restrictions: dismissalRestrictions }
+        : {}),
+      dismiss_stale_reviews: Boolean(reviews.dismiss_stale_reviews),
+      require_code_owner_reviews: Boolean(reviews.require_code_owner_reviews),
+      required_approving_review_count: Math.max(
+        reviews.required_approving_review_count ?? 0,
+        0,
+      ),
+      require_last_push_approval: Boolean(reviews.require_last_push_approval),
+    },
+    restrictions: mapRestrictions(current.restrictions),
+    required_conversation_resolution: true,
+    required_linear_history: Boolean(current.required_linear_history?.enabled),
+    allow_force_pushes: false,
+    allow_deletions: false,
+    block_creations: Boolean(current.block_creations?.enabled),
+    lock_branch: Boolean(current.lock_branch?.enabled),
+    allow_fork_syncing: Boolean(current.allow_fork_syncing?.enabled),
+  };
+}
+
+function mapRestrictions(
+  restrictions: RestrictionsInput | null | undefined,
+): RestrictionsOutput | null {
+  if (!restrictions) return null;
+  return {
+    users: (restrictions.users ?? []).map((user) =>
+      typeof user === "string" ? user : (user.login ?? user),
+    ),
+    teams: (restrictions.teams ?? []).map((team) =>
+      typeof team === "string" ? team : (team.slug ?? team),
+    ),
+    apps: (restrictions.apps ?? []).map((app) =>
+      typeof app === "string" ? app : (app.slug ?? app),
+    ),
+  };
+}
+
+export function parseLabels(source: string): Label[] {
+  const labels: Label[] = [];
+  let label: Partial<Label> | undefined;
+
+  for (const line of source.split("\n")) {
+    const name = line.match(/^\s*- name:\s*(.+)\s*$/);
+    if (name) {
+      if (label) labels.push(validateLabel(label));
+      label = { name: parseYamlString(name[1] as string) };
+      continue;
+    }
+
+    const property = line.match(/^\s+(description|color):\s*(.+)\s*$/);
+    if (label && property) {
+      const key = property[1] as "description" | "color";
+      label[key] = parseYamlString(property[2] as string);
+    }
+  }
+
+  if (label) labels.push(validateLabel(label));
+  if (labels.length === 0)
+    throw new Error("No labels found in .github/labels.yml.");
+  return labels;
+}
+
+function parseYamlString(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"')) return JSON.parse(trimmed) as string;
+  if (trimmed.startsWith("'"))
+    return trimmed.slice(1, -1).replaceAll("''", "'");
+  return trimmed;
+}
+
+function validateLabel(label: Partial<Label>): Label {
+  if (!label.name || label.description === undefined || !label.color) {
+    throw new Error(`Incomplete label definition: ${label.name ?? "unknown"}`);
+  }
+  return label as Label;
+}
+
+export function diffLabels(
+  desired: Label[],
+  current: CurrentLabel[],
+  renames: ReadonlyMap<string, string> = LABEL_RENAMES,
+): LabelDiff {
+  const currentByName = new Map(
+    current.map((label) => [label.name.toLowerCase(), label]),
+  );
+  for (const [previousName, nextName] of renames) {
+    if (
+      currentByName.has(previousName.toLowerCase()) &&
+      currentByName.has(nextName.toLowerCase())
+    ) {
+      throw new Error(
+        `Cannot migrate label '${previousName}' because '${nextName}' already exists. Merge their assignments manually before setup.`,
+      );
+    }
+  }
+  const desiredNames = new Set(
+    desired.map((label) => label.name.toLowerCase()),
+  );
+  const create = [];
+  const update = [];
+  const renamedCurrentNames = new Set();
+
+  for (const label of desired) {
+    let existing = currentByName.get(label.name.toLowerCase());
+    if (!existing) {
+      const previousName = [...renames.entries()].find(
+        ([, nextName]) => nextName.toLowerCase() === label.name.toLowerCase(),
+      )?.[0];
+      existing = previousName
+        ? currentByName.get(previousName.toLowerCase())
+        : undefined;
+      if (existing) renamedCurrentNames.add(existing.name.toLowerCase());
+    }
+    if (!existing) {
+      create.push(label);
+      continue;
+    }
+    if (
+      existing.name !== label.name ||
+      (existing.description ?? "") !== label.description ||
+      existing.color.toLowerCase() !== label.color.toLowerCase()
+    ) {
+      update.push({ current: existing, desired: label });
+    }
+  }
+
+  const remove = current.filter(
+    (label) =>
+      !desiredNames.has(label.name.toLowerCase()) &&
+      !renamedCurrentNames.has(label.name.toLowerCase()),
+  );
+  return { create, update, remove };
+}
+
+export function diffObject<Current extends object, Desired extends object>(
+  current: Current | undefined,
+  desired: Desired,
+): ObjectDiff[] {
+  const currentRecord = current as Record<string, unknown> | undefined;
+  return Object.entries(desired)
+    .filter(
+      ([key, value]) =>
+        JSON.stringify(currentRecord?.[key]) !== JSON.stringify(value),
+    )
+    .map(([key, value]) => ({
+      key,
+      current: currentRecord?.[key],
+      desired: value,
+    }));
+}
+
+export { REQUIRED_CHECK, REPOSITORY_RULESET_NAME };

--- a/scripts/setup/github/repository.mts
+++ b/scripts/setup/github/repository.mts
@@ -1,0 +1,583 @@
+import { readFileSync } from "node:fs";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import process from "node:process";
+import type { Interface } from "node:readline/promises";
+
+import {
+  AI_VARIABLES,
+  buildActionsSettings,
+  buildBranchProtection,
+  buildMainRuleset,
+  buildRepositorySettings,
+  diffLabels,
+  diffObject,
+  parseArguments,
+  parseLabels,
+  REPOSITORY_RULESET_NAME,
+  REQUIRED_CHECK,
+} from "./policy.mts";
+import type {
+  ActionsPermissionsState,
+  ActionsSettings,
+  ActionsState,
+  BranchProtectionInput,
+  CurrentLabel,
+  Label,
+  LabelDiff,
+  ObjectDiff,
+  RepositoryMetadata,
+  SelectedActionsState,
+  SetupArguments,
+  WorkflowState,
+} from "./policy.mts";
+import {
+  api,
+  CommandError,
+  preflight,
+  repositoryRoot,
+  runCommand,
+} from "./lib.mts";
+import type { RepositoryRestState } from "./lib.mts";
+
+interface MetadataResult {
+  metadata: RepositoryMetadata;
+  topics: string[] | undefined;
+  currentTopics: string[] | undefined;
+}
+
+interface ExistingAiVariable {
+  name: string;
+  value: string;
+}
+
+interface AiVariableChange extends ExistingAiVariable {
+  current: string;
+}
+
+interface TopicsResponse {
+  names?: string[];
+}
+
+interface GitRefResponse {
+  object: {
+    sha: string;
+  };
+}
+
+interface WorkflowRunListEntry {
+  databaseId: number;
+}
+
+interface WorkflowJob {
+  name: string;
+  conclusion: string | null;
+}
+
+interface WorkflowRun {
+  headSha: string;
+  conclusion: string | null;
+  jobs: WorkflowJob[];
+}
+
+interface CheckRun {
+  name: string;
+  conclusion: string | null;
+  app?: {
+    id?: number | null;
+    slug?: string;
+  };
+}
+
+interface CheckRunsResponse {
+  check_runs: CheckRun[];
+}
+
+interface RulesetResponse {
+  id: number;
+  name: string;
+  source_type?: string;
+}
+
+async function ask(
+  question: string,
+  defaultValue: string,
+  readline: Interface,
+): Promise<string> {
+  const suffix = defaultValue ? ` [${defaultValue}]` : "";
+  const answer = (await readline.question(`${question}${suffix}: `)).trim();
+  return answer || defaultValue || "";
+}
+
+async function confirm(
+  question: string,
+  defaultValue: boolean,
+  readline: Interface,
+): Promise<boolean> {
+  const hint = defaultValue ? "Y/n" : "y/N";
+  const answer = (await readline.question(`${question} [${hint}]: `))
+    .trim()
+    .toLowerCase();
+  if (!answer) return defaultValue;
+  return answer === "y" || answer === "yes";
+}
+
+async function collectMetadata(
+  state: RepositoryRestState,
+  readline: Interface,
+): Promise<MetadataResult> {
+  const description = await ask(
+    "Repository description",
+    state.description ?? "",
+    readline,
+  );
+  const homepage = await ask("Homepage URL", state.homepage ?? "", readline);
+  const currentTopics =
+    api<TopicsResponse>("GET", `/repos/${state.full_name}/topics`)!.names ?? [];
+  const topics = await ask(
+    "Topics (comma separated)",
+    currentTopics.join(","),
+    readline,
+  );
+  return {
+    metadata: {
+      ...(description && description !== state.description
+        ? { description }
+        : {}),
+      ...(homepage && homepage !== (state.homepage ?? "") ? { homepage } : {}),
+    },
+    topics: topics
+      .split(",")
+      .map((topic) => topic.trim())
+      .filter(Boolean),
+    currentTopics,
+  };
+}
+
+function printDiff(title: string, changes: ObjectDiff[]): void {
+  console.log(`\n${title}`);
+  if (changes.length === 0) {
+    console.log("  No changes.");
+    return;
+  }
+  for (const change of changes) {
+    console.log(
+      `  ${change.key}: ${JSON.stringify(change.current)} -> ${JSON.stringify(change.desired)}`,
+    );
+  }
+}
+
+function printLabelDiff(changes: LabelDiff): void {
+  console.log("\nLabels");
+  for (const label of changes.create) console.log(`  Create: ${label.name}`);
+  for (const { current, desired } of changes.update) {
+    console.log(`  Update: ${current.name} -> ${desired.name}`);
+  }
+  for (const label of changes.remove) console.log(`  Delete: ${label.name}`);
+  if (
+    !changes.create.length &&
+    !changes.update.length &&
+    !changes.remove.length
+  ) {
+    console.log("  No changes.");
+  }
+}
+
+async function getAiVariableChanges(
+  repository: string,
+  readline: Interface,
+): Promise<AiVariableChange[]> {
+  if (!(await confirm("Configure optional AI variables", false, readline)))
+    return [];
+  const existing = JSON.parse(
+    runCommand("gh", [
+      "variable",
+      "list",
+      "--repo",
+      repository,
+      "--json",
+      "name,value",
+    ]),
+  ) as ExistingAiVariable[];
+  const byName = new Map(
+    existing.map((variable) => [variable.name, variable.value]),
+  );
+  const changes: AiVariableChange[] = [];
+
+  for (const name of AI_VARIABLES) {
+    const current = byName.get(name) ?? "";
+    const value = await ask(name, current, readline);
+    if (value && value !== current) changes.push({ name, current, value });
+  }
+  return changes;
+}
+
+function getCurrentLabels(repository: string): CurrentLabel[] {
+  const pages = api<CurrentLabel[]>(
+    "GET",
+    `/repos/${repository}/labels?per_page=100&page=1`,
+  )!;
+  // The starter manages fewer than 100 labels. Fail instead of silently pruning
+  // when that assumption stops being true.
+  if (pages.length === 100) {
+    throw new Error(
+      "Label count reached 100; pagination support is required before syncing.",
+    );
+  }
+  return pages;
+}
+
+function applyLabels(repository: string, changes: LabelDiff): void {
+  for (const label of changes.create) {
+    api("POST", `/repos/${repository}/labels`, label);
+  }
+  for (const { current, desired } of changes.update) {
+    api(
+      "PATCH",
+      `/repos/${repository}/labels/${encodeURIComponent(current.name)}`,
+      {
+        new_name: desired.name,
+        color: desired.color,
+        description: desired.description,
+      },
+    );
+  }
+  for (const label of changes.remove) {
+    api(
+      "DELETE",
+      `/repos/${repository}/labels/${encodeURIComponent(label.name)}`,
+    );
+  }
+}
+
+function getActionsState(repository: string): ActionsState {
+  const permissions = api<ActionsPermissionsState>(
+    "GET",
+    `/repos/${repository}/actions/permissions`,
+  )!;
+  const workflow = api<WorkflowState>(
+    "GET",
+    `/repos/${repository}/actions/permissions/workflow`,
+  )!;
+  let selectedActions: SelectedActionsState = {};
+  try {
+    selectedActions = api<SelectedActionsState>(
+      "GET",
+      `/repos/${repository}/actions/permissions/selected-actions`,
+    )!;
+  } catch {
+    // The selected-actions endpoint is unavailable until selected mode is active.
+  }
+  return { permissions, selectedActions, workflow };
+}
+
+function applyActionsSettings(
+  repository: string,
+  settings: ActionsSettings,
+): void {
+  api("PUT", `/repos/${repository}/actions/permissions`, settings.permissions);
+  api(
+    "PUT",
+    `/repos/${repository}/actions/permissions/selected-actions`,
+    settings.selectedActions,
+  );
+  api(
+    "PUT",
+    `/repos/${repository}/actions/permissions/workflow`,
+    settings.workflow,
+  );
+}
+
+const delay = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function runRequiredChecks(repository: string): Promise<number> {
+  const headSha = api<GitRefResponse>(
+    "GET",
+    `/repos/${repository}/git/ref/heads/main`,
+  )!.object.sha;
+  const existingRuns = JSON.parse(
+    runCommand("gh", [
+      "run",
+      "list",
+      "--repo",
+      repository,
+      "--workflow",
+      "tests.yml",
+      "--event",
+      "workflow_dispatch",
+      "--branch",
+      "main",
+      "--limit",
+      "20",
+      "--json",
+      "databaseId",
+    ]),
+  ) as WorkflowRunListEntry[];
+  const existingRunIds = new Set(
+    existingRuns.map(({ databaseId }) => databaseId),
+  );
+  runCommand("gh", [
+    "workflow",
+    "run",
+    "tests.yml",
+    "--repo",
+    repository,
+    "--ref",
+    "main",
+  ]);
+
+  let run: WorkflowRunListEntry | undefined;
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    await delay(2_000);
+    const runs = JSON.parse(
+      runCommand("gh", [
+        "run",
+        "list",
+        "--repo",
+        repository,
+        "--workflow",
+        "tests.yml",
+        "--event",
+        "workflow_dispatch",
+        "--branch",
+        "main",
+        "--limit",
+        "5",
+        "--json",
+        "databaseId",
+      ]),
+    ) as WorkflowRunListEntry[];
+    run = runs.find(({ databaseId }) => !existingRunIds.has(databaseId));
+    if (run) break;
+  }
+
+  if (!run)
+    throw new Error("Could not find the dispatched Tests workflow run.");
+  runCommand(
+    "gh",
+    [
+      "run",
+      "watch",
+      String(run.databaseId),
+      "--repo",
+      repository,
+      "--exit-status",
+    ],
+    { inherit: true },
+  );
+  const completedRun = JSON.parse(
+    runCommand("gh", [
+      "run",
+      "view",
+      String(run.databaseId),
+      "--repo",
+      repository,
+      "--json",
+      "headSha,conclusion,jobs",
+    ]),
+  ) as WorkflowRun;
+  const requiredJob = completedRun.jobs.find(
+    ({ name }) => name === REQUIRED_CHECK,
+  );
+  if (
+    completedRun.headSha !== headSha ||
+    completedRun.conclusion !== "success" ||
+    requiredJob?.conclusion !== "success"
+  ) {
+    throw new Error(
+      `Tests must report a successful '${REQUIRED_CHECK}' job for the current main commit.`,
+    );
+  }
+  const checkRuns = api<CheckRunsResponse>(
+    "GET",
+    `/repos/${repository}/commits/${headSha}/check-runs?per_page=100`,
+  )!.check_runs;
+  const requiredCheck = checkRuns.find(
+    (check) =>
+      check.name === REQUIRED_CHECK &&
+      check.conclusion === "success" &&
+      check.app?.slug === "github-actions",
+  );
+  if (!requiredCheck?.app?.id) {
+    throw new Error(
+      `Could not resolve the GitHub Actions App for '${REQUIRED_CHECK}'.`,
+    );
+  }
+  return requiredCheck.app.id;
+}
+
+function applyBranchProtection(
+  repository: string,
+  integrationId: number,
+): void {
+  let current: BranchProtectionInput = {};
+  try {
+    current = api<BranchProtectionInput>(
+      "GET",
+      `/repos/${repository}/branches/main/protection`,
+    )!;
+  } catch (error) {
+    if (!(error instanceof CommandError) || error.httpStatus !== 404)
+      throw error;
+  }
+  api(
+    "PUT",
+    `/repos/${repository}/branches/main/protection`,
+    buildBranchProtection(current, integrationId),
+  );
+}
+
+function isRulesetUnavailable(error: unknown): boolean {
+  return (
+    error instanceof CommandError && [403, 404, 422].includes(error.httpStatus)
+  );
+}
+
+function applyMainProtection(repository: string, integrationId: number): void {
+  const desired = buildMainRuleset(integrationId);
+  try {
+    const rulesets = api<RulesetResponse[]>(
+      "GET",
+      `/repos/${repository}/rulesets?includes_parents=false&targets=branch`,
+    )!;
+    const current = rulesets.find(
+      (ruleset) =>
+        ruleset.name === REPOSITORY_RULESET_NAME &&
+        ruleset.source_type === "Repository",
+    );
+    if (current) {
+      api("PUT", `/repos/${repository}/rulesets/${current.id}`, desired);
+    } else {
+      api("POST", `/repos/${repository}/rulesets`, desired);
+    }
+    console.log(`Applied ruleset: ${REPOSITORY_RULESET_NAME}`);
+  } catch (error) {
+    if (!isRulesetUnavailable(error)) throw error;
+    console.warn(
+      "Rulesets are unavailable; applying classic branch protection.",
+    );
+    applyBranchProtection(repository, integrationId);
+  }
+}
+
+export async function setupRepository(args: SetupArguments): Promise<void> {
+  const { repository, state } = preflight(args.repository);
+  const needsReadline = !args.defaults || (!args.yes && !args.dryRun);
+  const readline: Interface | undefined = needsReadline
+    ? createInterface({ input: process.stdin, output: process.stdout })
+    : undefined;
+
+  try {
+    console.log(`Target repository: ${repository}`);
+    const metadataResult: MetadataResult = args.defaults
+      ? { metadata: {}, topics: undefined, currentTopics: undefined }
+      : await collectMetadata(state, readline!);
+    const aiVariables: AiVariableChange[] = args.defaults
+      ? []
+      : await getAiVariableChanges(repository, readline!);
+    const repositorySettings = buildRepositorySettings(metadataResult.metadata);
+    const repositoryChanges = diffObject(state, repositorySettings);
+    const actionsState = getActionsState(repository);
+    const shaPinningRequired = Boolean(
+      actionsState.permissions.sha_pinning_required,
+    );
+    const actionsSettings = buildActionsSettings({ shaPinningRequired });
+    const desiredLabels = parseLabels(
+      readFileSync(path.join(repositoryRoot, ".github/labels.yml"), "utf8"),
+    );
+    const labelChanges = diffLabels(
+      desiredLabels,
+      getCurrentLabels(repository),
+    );
+
+    printDiff("Repository settings", repositoryChanges);
+    printDiff(
+      "Actions permissions",
+      diffObject(actionsState.permissions, actionsSettings.permissions),
+    );
+    printDiff(
+      "Selected actions",
+      diffObject(actionsState.selectedActions, actionsSettings.selectedActions),
+    );
+    printDiff(
+      "Workflow token permissions",
+      diffObject(actionsState.workflow, actionsSettings.workflow),
+    );
+    if (metadataResult.topics) {
+      printDiff(
+        "Repository topics",
+        diffObject(
+          { topics: metadataResult.currentTopics },
+          { topics: metadataResult.topics },
+        ),
+      );
+    }
+    printDiff(
+      "AI variables",
+      aiVariables.map((variable) => ({
+        key: variable.name,
+        current: variable.current || undefined,
+        desired: variable.value,
+      })),
+    );
+    printLabelDiff(labelChanges);
+    console.log(`\nMain protection: ${REPOSITORY_RULESET_NAME}`);
+    console.log(`Required status check: ${REQUIRED_CHECK}`);
+    if (shaPinningRequired) {
+      console.warn(
+        "Existing SHA pinning is enabled. Setup will not disable it, but the starter's tag-based actions must be pinned before workflows can run.",
+      );
+    }
+
+    if (args.dryRun) {
+      console.log("\nDry run complete. No changes were applied.");
+      return;
+    }
+    if (
+      !args.yes &&
+      !(await confirm("Apply these changes", false, readline!))
+    ) {
+      console.log("Setup cancelled.");
+      return;
+    }
+    if (shaPinningRequired) {
+      throw new Error(
+        "Cannot complete setup while SHA pinning is enabled and workflows use tag references.",
+      );
+    }
+
+    api("PATCH", `/repos/${repository}`, repositorySettings);
+    if (metadataResult.topics) {
+      api("PUT", `/repos/${repository}/topics`, {
+        names: metadataResult.topics,
+      });
+    }
+    applyActionsSettings(repository, actionsSettings);
+    for (const variable of aiVariables) {
+      runCommand("gh", [
+        "variable",
+        "set",
+        variable.name,
+        "--repo",
+        repository,
+        "--body",
+        variable.value,
+      ]);
+    }
+    applyLabels(repository, labelChanges);
+    const integrationId = await runRequiredChecks(repository);
+    applyMainProtection(repository, integrationId);
+    console.log("\nGitHub repository setup completed.");
+  } finally {
+    readline?.close();
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  setupRepository(parseArguments(process.argv.slice(2))).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/setup/github/secrets.mts
+++ b/scripts/setup/github/secrets.mts
@@ -1,0 +1,208 @@
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import type { Interface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+import { COPILOT_SECRETS, parseArguments } from "./policy.mts";
+import type { SetupArguments } from "./policy.mts";
+import { api, preflight, repositoryRoot, runCommand } from "./lib.mts";
+import type { PreflightResult } from "./lib.mts";
+
+type Repository = PreflightResult["repository"];
+type SecretName = string;
+type SecretNames = SecretName[];
+
+interface Environment {
+  name: string;
+}
+
+interface EnvironmentApiResponse {
+  environments: Environment[];
+}
+
+interface SecretApiResponse {
+  name: SecretName;
+}
+
+type SecretTarget =
+  | { type: "repository" }
+  | { type: "environment"; name: string };
+
+async function ask(
+  question: string,
+  defaultValue: string,
+  readline: Interface,
+): Promise<string> {
+  const suffix = defaultValue ? ` [${defaultValue}]` : "";
+  const answer = (await readline.question(`${question}${suffix}: `)).trim();
+  return answer || defaultValue || "";
+}
+
+async function confirm(
+  question: string,
+  defaultValue: boolean,
+  readline: Interface,
+): Promise<boolean> {
+  const hint = defaultValue ? "Y/n" : "y/N";
+  const answer = (await readline.question(`${question} [${hint}]: `))
+    .trim()
+    .toLowerCase();
+  if (!answer) return defaultValue;
+  return answer === "y" || answer === "yes";
+}
+
+function validateSecretName(name: string): SecretName {
+  if (!/^[A-Z_][A-Z0-9_]*$/.test(name) || name.startsWith("GITHUB_")) {
+    throw new Error(
+      "Secret names must use uppercase letters, numbers, and underscores, and cannot start with GITHUB_.",
+    );
+  }
+  return name;
+}
+
+function listEnvironments(repository: Repository): Environment[] {
+  return (
+    api<EnvironmentApiResponse>(
+      "GET",
+      `/repos/${repository}/environments?per_page=100`,
+    )!.environments ?? []
+  );
+}
+
+async function chooseSecretTarget(
+  repository: Repository,
+  args: SetupArguments,
+  readline: Interface,
+): Promise<SecretTarget> {
+  if (args.scope) return { type: "repository" };
+  if (args.environment) return { type: "environment", name: args.environment };
+
+  const environments = listEnvironments(repository);
+  console.log("\nSecret scope");
+  console.log("  1. Repository (global)");
+  environments.forEach((environment, index) => {
+    console.log(`  ${index + 2}. ${environment.name}`);
+  });
+  console.log(`  ${environments.length + 2}. Create an environment`);
+  const choice = Number(await ask("Choose a scope", "1", readline));
+
+  if (choice === 1) return { type: "repository" };
+  if (choice >= 2 && choice <= environments.length + 1) {
+    return { type: "environment", name: environments[choice - 2]!.name };
+  }
+  if (choice === environments.length + 2) {
+    const name = await ask("Environment name", "production", readline);
+    if (!name) throw new Error("Environment name is required.");
+    return { type: "environment", name };
+  }
+  throw new Error("Invalid scope selection.");
+}
+
+function listSecretNames(
+  repository: Repository,
+  target: SecretTarget,
+): SecretNames {
+  const args = ["secret", "list", "--repo", repository, "--json", "name"];
+  if (target.type === "environment") args.push("--env", target.name);
+  return (JSON.parse(runCommand("gh", args)) as SecretApiResponse[]).map(
+    ({ name }) => name,
+  );
+}
+
+function setSecret(
+  repository: Repository,
+  target: SecretTarget,
+  name: SecretName,
+): void {
+  const args = ["secret", "set", name, "--repo", repository];
+  if (target.type === "environment") args.push("--env", target.name);
+  const result = spawnSync("gh", args, {
+    cwd: repositoryRoot,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) throw new Error(`Failed to set ${name}.`);
+}
+
+export async function setupSecrets(args: SetupArguments): Promise<void> {
+  const { repository } = preflight(args.repository);
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    console.log(`Target repository: ${repository}`);
+    let names: SecretNames;
+    let target: SecretTarget;
+
+    if (args.secretName) {
+      names = [validateSecretName(args.secretName)];
+      target = await chooseSecretTarget(repository, args, readline);
+    } else {
+      const useCopilotPreset = await confirm(
+        "Configure Copilot credentials",
+        true,
+        readline,
+      );
+      if (useCopilotPreset) {
+        names = COPILOT_SECRETS;
+        target = { type: "repository" };
+      } else {
+        names = [validateSecretName(await ask("Secret name", "", readline))];
+        target = await chooseSecretTarget(repository, args, readline);
+      }
+    }
+
+    const environments =
+      target.type === "environment" ? listEnvironments(repository) : [];
+    const environmentExists =
+      target.type === "environment" &&
+      environments.some(({ name }) => name === target.name);
+    if (target.type === "environment") {
+      if (!environmentExists) {
+        console.log(`Environment will be created: ${target.name}`);
+      }
+      console.warn(
+        `Jobs must declare environment: ${target.name} to access these secrets.`,
+      );
+    }
+
+    const existing =
+      target.type === "environment" && !environmentExists
+        ? []
+        : listSecretNames(repository, target);
+    for (const name of names) {
+      const action = existing.includes(name) ? "Overwrite" : "Create";
+      console.log(`${action} ${target.type} secret: ${name}`);
+    }
+    if (args.dryRun) {
+      console.log("Dry run complete. No secrets were changed.");
+      return;
+    }
+    if (!args.yes && !(await confirm("Continue", false, readline))) {
+      console.log("Secret setup cancelled.");
+      return;
+    }
+    if (target.type === "environment" && !environmentExists) {
+      api<unknown>(
+        "PUT",
+        `/repos/${repository}/environments/${encodeURIComponent(target.name)}`,
+        {},
+      );
+    }
+    for (const name of names) setSecret(repository, target, name);
+    console.log("Secret setup completed.");
+  } finally {
+    readline.close();
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  setupSecrets(parseArguments(["secrets", ...process.argv.slice(2)])).catch(
+    (error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/scripts/tests/setup-github.test.mjs
+++ b/scripts/tests/setup-github.test.mjs
@@ -1,0 +1,347 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildActionsSettings,
+  buildBranchProtection,
+  buildMainRuleset,
+  buildRepositorySettings,
+  diffLabels,
+  diffObject,
+  parseArguments,
+  parseLabels,
+} from "../setup/github/policy.mts";
+
+describe("parseArguments", () => {
+  it("uses interactive repository setup by default", () => {
+    assert.deepEqual(parseArguments([]), {
+      mode: "setup",
+      dryRun: false,
+      defaults: false,
+      yes: false,
+      repository: undefined,
+      scope: undefined,
+      environment: undefined,
+      secretName: undefined,
+    });
+  });
+
+  it("parses non-interactive setup flags", () => {
+    assert.deepEqual(
+      parseArguments([
+        "--repo",
+        "owner/repo",
+        "--defaults",
+        "--yes",
+        "--dry-run",
+      ]),
+      {
+        mode: "setup",
+        dryRun: true,
+        defaults: true,
+        yes: true,
+        repository: "owner/repo",
+        scope: undefined,
+        environment: undefined,
+        secretName: undefined,
+      },
+    );
+  });
+
+  it("parses an environment secret target", () => {
+    assert.deepEqual(
+      parseArguments([
+        "secrets",
+        "--environment",
+        "production",
+        "--name",
+        "DATABASE_URL",
+      ]),
+      {
+        mode: "secrets",
+        dryRun: false,
+        defaults: false,
+        yes: false,
+        repository: undefined,
+        scope: undefined,
+        environment: "production",
+        secretName: "DATABASE_URL",
+      },
+    );
+  });
+
+  it("rejects ambiguous and unsafe secret arguments", () => {
+    assert.throws(
+      () =>
+        parseArguments([
+          "secrets",
+          "--scope",
+          "repository",
+          "--environment",
+          "production",
+          "--name",
+          "TOKEN",
+        ]),
+      /either --scope or --environment/,
+    );
+    assert.throws(
+      () => parseArguments(["secrets", "--environment", "production"]),
+      /require --name/,
+    );
+    assert.throws(
+      () => parseArguments(["secrets", "--defaults"]),
+      /cannot be configured with --defaults/,
+    );
+  });
+});
+
+describe("repository settings", () => {
+  it("builds the agreed merge and feature policy", () => {
+    assert.deepEqual(buildRepositorySettings(), {
+      default_branch: "main",
+      has_issues: true,
+      has_projects: true,
+      has_wiki: false,
+      has_discussions: false,
+      allow_merge_commit: true,
+      allow_squash_merge: true,
+      allow_rebase_merge: false,
+      allow_auto_merge: false,
+      delete_branch_on_merge: true,
+      merge_commit_title: "PR_TITLE",
+      merge_commit_message: "BLANK",
+      squash_merge_commit_title: "PR_TITLE",
+      squash_merge_commit_message: "COMMIT_MESSAGES",
+    });
+  });
+
+  it("adds only explicitly supplied metadata", () => {
+    assert.equal(
+      buildRepositorySettings({ description: "Example" }).description,
+      "Example",
+    );
+  });
+});
+
+describe("Actions settings", () => {
+  it("uses selected actions with a read-only default token", () => {
+    const settings = buildActionsSettings();
+
+    assert.deepEqual(settings.permissions, {
+      enabled: true,
+      allowed_actions: "selected",
+      sha_pinning_required: false,
+    });
+    assert.equal(settings.selectedActions.github_owned_allowed, true);
+    assert.equal(settings.selectedActions.verified_allowed, false);
+    assert.deepEqual(settings.selectedActions.patterns_allowed, [
+      "dorny/paths-filter@*",
+      "release-drafter/release-drafter@*",
+      "micnncim/action-label-syncer@*",
+      "sst/opencode/github@*",
+    ]);
+    assert.deepEqual(settings.workflow, {
+      default_workflow_permissions: "read",
+      can_approve_pull_request_reviews: false,
+    });
+  });
+
+  it("preserves an existing SHA pinning requirement", () => {
+    assert.equal(
+      buildActionsSettings({ shaPinningRequired: true }).permissions
+        .sha_pinning_required,
+      true,
+    );
+  });
+});
+
+describe("main protection", () => {
+  it("builds an active main ruleset with the required CI gate", () => {
+    const ruleset = buildMainRuleset(15368);
+    const pullRequestRule = ruleset.rules.find(
+      (rule) => rule.type === "pull_request",
+    );
+    const statusRule = ruleset.rules.find(
+      (rule) => rule.type === "required_status_checks",
+    );
+
+    assert.equal(ruleset.name, "Starter: protect main");
+    assert.deepEqual(ruleset.conditions.ref_name.include, ["refs/heads/main"]);
+    assert.equal(ruleset.bypass_actors[0].bypass_mode, "always");
+    assert.equal(pullRequestRule.parameters.required_approving_review_count, 0);
+    assert.equal(
+      pullRequestRule.parameters.required_review_thread_resolution,
+      true,
+    );
+    assert.deepEqual(pullRequestRule.parameters.allowed_merge_methods, [
+      "merge",
+      "squash",
+    ]);
+    assert.deepEqual(statusRule.parameters.required_status_checks, [
+      { context: "Required checks", integration_id: 15368 },
+    ]);
+    assert.equal(
+      statusRule.parameters.strict_required_status_checks_policy,
+      true,
+    );
+  });
+
+  it("preserves stricter classic protection while adding the required check", () => {
+    const protection = buildBranchProtection(
+      {
+        required_status_checks: {
+          contexts: ["security"],
+          checks: [{ context: "security", app_id: 42 }],
+        },
+        enforce_admins: { enabled: true },
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: true,
+          require_code_owner_reviews: true,
+          required_approving_review_count: 2,
+          require_last_push_approval: true,
+        },
+        required_linear_history: { enabled: true },
+      },
+      15368,
+    );
+
+    assert.deepEqual(protection.required_status_checks, {
+      strict: true,
+      contexts: ["security", "Required checks"],
+      checks: [
+        { context: "security", app_id: 42 },
+        { context: "Required checks", app_id: 15368 },
+      ],
+    });
+    assert.equal(protection.enforce_admins, true);
+    assert.equal(
+      protection.required_pull_request_reviews.required_approving_review_count,
+      2,
+    );
+    assert.equal(protection.required_linear_history, true);
+    assert.equal(protection.allow_force_pushes, false);
+    assert.equal(protection.allow_deletions, false);
+  });
+});
+
+describe("labels", () => {
+  const source = `
+- name: "feature"
+  description: "Feature addition"
+  color: "0E8A16"
+- name: 'question'
+  description: 'General inquiries'
+  color: 'D876E3'
+`;
+
+  it("parses the supported labels manifest", () => {
+    assert.deepEqual(parseLabels(source), [
+      {
+        name: "feature",
+        description: "Feature addition",
+        color: "0E8A16",
+      },
+      {
+        name: "question",
+        description: "General inquiries",
+        color: "D876E3",
+      },
+    ]);
+  });
+
+  it("fails closed for incomplete label definitions", () => {
+    assert.throws(
+      () => parseLabels('- name: "feature"\n  color: "0E8A16"\n'),
+      /Incomplete label definition/,
+    );
+  });
+
+  it("computes create, update, and delete operations", () => {
+    const desired = parseLabels(source);
+    const changes = diffLabels(desired, [
+      { name: "feature", description: "Old", color: "ffffff" },
+      { name: "obsolete", description: "Remove", color: "000000" },
+    ]);
+
+    assert.deepEqual(
+      changes.create.map((label) => label.name),
+      ["question"],
+    );
+    assert.deepEqual(
+      changes.update.map(({ desired: label }) => label.name),
+      ["feature"],
+    );
+    assert.deepEqual(
+      changes.remove.map((label) => label.name),
+      ["obsolete"],
+    );
+  });
+
+  it("updates labels whose GitHub description is null", () => {
+    const desired = [
+      { name: "feature", description: "Feature addition", color: "0E8A16" },
+    ];
+    const changes = diffLabels(desired, [
+      { name: "feature", description: null, color: "0E8A16" },
+    ]);
+
+    assert.equal(changes.update.length, 1);
+    assert.equal(changes.update[0].desired.description, "Feature addition");
+  });
+
+  it("renames the legacy question label without deleting assignments", () => {
+    const desired = [
+      { name: "💬question", description: "Questions", color: "D876E3" },
+    ];
+    const changes = diffLabels(desired, [
+      { name: "💬quesion", description: "Questions", color: "D876E3" },
+    ]);
+
+    assert.equal(changes.create.length, 0);
+    assert.equal(changes.remove.length, 0);
+    assert.deepEqual(changes.update, [
+      {
+        current: {
+          name: "💬quesion",
+          description: "Questions",
+          color: "D876E3",
+        },
+        desired: {
+          name: "💬question",
+          description: "Questions",
+          color: "D876E3",
+        },
+      },
+    ]);
+  });
+
+  it("fails closed when both legacy and corrected labels exist", () => {
+    const desired = [
+      { name: "💬question", description: "Questions", color: "D876E3" },
+    ];
+
+    assert.throws(
+      () =>
+        diffLabels(desired, [
+          { name: "💬quesion", description: "Questions", color: "D876E3" },
+          { name: "💬question", description: "Questions", color: "D876E3" },
+        ]),
+      /Merge their assignments manually/,
+    );
+  });
+});
+
+describe("diffObject", () => {
+  it("returns only changed desired fields", () => {
+    assert.deepEqual(
+      diffObject(
+        { enabled: true, mode: "all", untouched: 1 },
+        {
+          enabled: true,
+          mode: "selected",
+        },
+      ),
+      [{ key: "mode", current: "all", desired: "selected" }],
+    );
+  });
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["setup/**/*.mts"]
+}


### PR DESCRIPTION
## Overview

Add typed, interactive GitHub repository setup commands so repositories created from this starter can apply consistent settings without repeating manual configuration.

## Changes

- Add `nps setup.github` with dry-run, defaults, confirmation, metadata, Actions permissions, labels, AI variables, and `main` protection.
- Add `nps setup.github.secrets` for Repository and Environment secrets while delegating secret input directly to the GitHub CLI.
- Add strict TypeScript checking and Node tests for provider-scoped setup scripts under `scripts/setup/github`.
- Add a stable `Required checks` CI gate suitable for Rulesets and classic branch protection fallback.
- Align branch-prefix labels, Release Drafter rules, and the question-label migration.
- Document setup commands, managed settings, safety behavior, and known limitations.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

<details>
  <summary>nps typecheck</summary>

  Passed, including strict checks for `scripts/setup/**/*.mts` and all workspaces.
</details>

<details>
  <summary>nps test</summary>

  Passed: 26 repository script tests and 7 web tests.
</details>

<details>
  <summary>Setup dry runs</summary>

  `nps "setup.github --dry-run --defaults"` and the Environment secret dry-run both completed without mutations.
</details>

## Screenshots

Not applicable.

## Notes

- The setup flow was verified against the live repository in dry-run mode only; no repository settings or secrets were mutated.
- NPS requires the command and forwarded arguments to be enclosed in quotes.
- Rulesets fall back to classic branch protection when the repository plan does not support them.
- `/oc task` write permissions remain outside this PR's scope.
