### PR TITLE
Add parallel web E2E test foundation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,10 +144,48 @@ jobs:
         if: matrix.run == 'true'
         run: npx nps test.ci.${{ matrix.target }}
 
+  e2e:
+    needs: [setup, changes]
+    runs-on: ubuntu-latest
+    if: needs.setup.result == 'success' && needs.changes.outputs.web == 'true'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+          package-manager-cache: false
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Restore pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ needs.setup.outputs.pnpm-store-dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - name: Prepare
+        run: npx nps prepare.ci.web
+      - name: Install Chromium
+        working-directory: out/apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Test E2E
+        run: npx nps test.ci.web.e2e.all
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-playwright-artifacts
+          path: |
+            out/apps/web/playwright-report/
+            out/apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   required-checks:
     name: Required checks
     if: always()
-    needs: [script-tests, changes, setup, test]
+    needs: [script-tests, changes, setup, test, e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -157,11 +195,12 @@ jobs:
           WEB_CHANGED: ${{ needs.changes.outputs.web }}
           SETUP_RESULT: ${{ needs.setup.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
         run: |
           if [[ "$SCRIPT_TESTS_RESULT" != "success" || "$CHANGES_RESULT" != "success" ]]; then
             exit 1
           fi
 
-          if [[ "$WEB_CHANGED" == "true" && ( "$SETUP_RESULT" != "success" || "$TEST_RESULT" != "success" ) ]]; then
+          if [[ "$WEB_CHANGED" == "true" && ( "$SETUP_RESULT" != "success" || "$TEST_RESULT" != "success" || "$E2E_RESULT" != "success" ) ]]; then
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ node_modules
 
 # testing
 coverage
+playwright-report/
+playwright-live-report/
+test-results/
+live-test-results/
 
 # next.js
 .next/

--- a/.opencode/skills/add-web-test/SKILL.md
+++ b/.opencode/skills/add-web-test/SKILL.md
@@ -41,16 +41,18 @@ present) and correctly handles async server components.
    from raw `@testing-library/react`. `testUtils.tsx` re-exports
    `customRender` as `render` and also re-exports `@testing-library/react` and
    `@testing-library/user-event`:
+
    ```tsx
-   import { render, act, waitFor, screen } from '../testUtils';
+   import { render, act, waitFor, screen } from "../testUtils";
    ```
 
 3. **For async server components**, `await` the component before rendering
    (they return a `Promise<ReactElement>`):
-   ```tsx
-   import MyPage from '../../app/page';
 
-   it('renders', async () => {
+   ```tsx
+   import MyPage from "../../app/page";
+
+   it("renders", async () => {
      await act(async () => {
        render(await MyPage());
      });
@@ -59,6 +61,7 @@ present) and correctly handles async server components.
      });
    });
    ```
+
    See `src/tests/app/page.test.tsx:5-14` for the exact pattern.
 
 4. **For client components** that use Redux, the wrapper already provides
@@ -82,7 +85,7 @@ present) and correctly handles async server components.
 <Verify>
 
 - `cd apps/web && pnpm test -- path/to/test.test.tsx` — single file
-- `nps test.web` — all web app tests
+- `nps test.web` / `nps test.web.unit` — all Vitest unit/component tests through Turbo
 - `nps test.watch` — watch mode
 - `nps lint.web` + `nps typecheck.web` — keep the test green with lint/types
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,20 @@ full options.
 - **Format**: `nps format` (all), `nps format.web`, `nps format.packages`
 - **Typecheck**: `nps typecheck` (all), `nps typecheck.web`,
   `nps typecheck.packages` (or `nps typecheck.packages.ui`)
-- **Test**: `nps test` (all), `nps test.web` (web app tests), `nps test.watch`
+- **Test**: `nps test` (parallel workspace unit/component),
+  `nps test.web.unit`, `nps test.e2e` (parallel workspace E2E),
+  `nps test.web.e2e.[desktop|tablet|mobile|all]`, `nps test.web.live`,
+  `nps test.watch`
 - **Dev**: `nps dev` (all), `nps dev.web`
 - **Single test**: `cd apps/web && pnpm test -- path/to/test.test.tsx`
+
+Workspace apps participate by defining `test`, `test:ci`, and `test:e2e`
+package scripts. E2E tasks run concurrently, so each app must isolate ports,
+databases, temporary files, and external services. Keep side-effecting external
+checks in an opt-in `test:live` script; never include live tests in default or
+required CI commands.
 
 ## App- and Package-specific Guidelines
 
 For app- and package-specific guidelines, see @apps/web/AGENTS.md and
-@packages/*/AGENTS.md.
+@packages/\*/AGENTS.md.

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ nps dev
 The web app reads runtime configuration from `apps/web/.env`. See
 `apps/web/.env.example` for the full list:
 
-| Variable     | Purpose                                                        |
-| ------------ | -------------------------------------------------------------- |
-| `BASE_URL`   | Base URL used for absolute links, sitemap, robots, and API calls |
-| `LOG_LEVEL`  | Logger verbosity: `verbose` / `debug` / `info` / `log` / `warn` / `error` / `fatal` (default: `info`) |
+| Variable    | Purpose                                                                                               |
+| ----------- | ----------------------------------------------------------------------------------------------------- |
+| `BASE_URL`  | Base URL used for absolute links, sitemap, robots, and API calls                                      |
+| `LOG_LEVEL` | Logger verbosity: `verbose` / `debug` / `info` / `log` / `warn` / `error` / `fatal` (default: `info`) |
 
 ### GitHub Actions Variables
 
@@ -168,25 +168,37 @@ Commands are run with [`nps`](https://github.com/seblepouls/nps)
 (npm-script-runner). See [package-scripts.js](package-scripts.js) for the full
 list.
 
-| Command              | Description                                  |
-| -------------------- | -------------------------------------------- |
-| `nps dev`            | Start the web dev server (Turborepo dev)     |
-| `nps build`          | Build all apps and packages                  |
-| `nps build.web`      | Build only the web app                       |
-| `nps build.packages` | Build shared packages (constants, types)     |
-| `nps lint`           | Lint all apps and packages                   |
-| `nps lint.web`       | Lint only the web app                        |
-| `nps format`         | Format all apps and packages                 |
-| `nps typecheck`      | Type-check all apps and packages             |
-| `nps test`           | Run repository script and web app tests      |
-| `nps test.watch`     | Run web app tests in watch mode              |
-| `nps setup.github`   | Configure GitHub repository settings         |
+| Command                    | Description                                 |
+| -------------------------- | ------------------------------------------- |
+| `nps dev`                  | Start the web dev server (Turborepo dev)    |
+| `nps build`                | Build all apps and packages                 |
+| `nps build.web`            | Build only the web app                      |
+| `nps build.packages`       | Build shared packages (constants, types)    |
+| `nps lint`                 | Lint all apps and packages                  |
+| `nps lint.web`             | Lint only the web app                       |
+| `nps format`               | Format all apps and packages                |
+| `nps typecheck`            | Type-check all apps and packages            |
+| `nps test`                 | Run repository and workspace unit tests     |
+| `nps test.web.unit`        | Run web unit/component tests                |
+| `nps test.e2e`             | Run all workspace E2E tasks                 |
+| `nps test.web.e2e.all`     | Run web E2E tests at every viewport         |
+| `nps test.web.live`        | Run web E2E tests against an external URL   |
+| `nps test.watch`           | Run web app tests in watch mode             |
+| `nps setup.github`         | Configure GitHub repository settings        |
 | `nps setup.github.secrets` | Configure Repository or Environment secrets |
-| `nps docker.build.web` | Build the web Docker image                  |
-| `nps docker.start.web` | Start the web container via docker-compose  |
-| `nps start`          | Start the built web app in production mode   |
+| `nps docker.build.web`     | Build the web Docker image                  |
+| `nps docker.start.web`     | Start the web container via docker-compose  |
+| `nps start`                | Start the built web app in production mode  |
 
 > Single test file: `cd apps/web && pnpm test -- path/to/test.test.tsx`
+
+Workspace apps join the parallel test orchestration by defining `test` for
+unit/component tests and `test:e2e` for E2E tests. Live tests are opt-in and
+app-scoped because they may access external services. For example:
+
+```sh
+PLAYWRIGHT_BASE_URL=https://staging.example.com nps test.web.live
+```
 
 ## 🔄 GitHub Actions Workflows
 
@@ -196,14 +208,14 @@ project standards.
 
 ### Available Workflows
 
-| Workflow            | Trigger                 | Purpose                                                                |
-| ------------------- | ----------------------- | ---------------------------------------------------------------------- |
-| **Assign Labels**   | PR opened               | Automatically assigns labels based on branch naming convention         |
-| **Sync Labels**     | Manual dispatch         | Synchronizes repository labels with `.github/labels.yml` configuration |
-| **Display Details** | Manual dispatch         | Displays project, apps, and repository information                     |
-| **Release Drafter** | Push/PR to main         | Creates and updates draft releases with categorized changes            |
-| **Tests**           | Push/PR to main         | Runs tests for affected apps and packages                              |
-| **Run AI Agent**    | Issue/PR comment        | Executes AI-powered code tasks via `/oc` or `/opencode` commands       |
+| Workflow            | Trigger          | Purpose                                                                |
+| ------------------- | ---------------- | ---------------------------------------------------------------------- |
+| **Assign Labels**   | PR opened        | Automatically assigns labels based on branch naming convention         |
+| **Sync Labels**     | Manual dispatch  | Synchronizes repository labels with `.github/labels.yml` configuration |
+| **Display Details** | Manual dispatch  | Displays project, apps, and repository information                     |
+| **Release Drafter** | Push/PR to main  | Creates and updates draft releases with categorized changes            |
+| **Tests**           | Push/PR to main  | Runs tests for affected apps and packages                              |
+| **Run AI Agent**    | Issue/PR comment | Executes AI-powered code tasks via `/oc` or `/opencode` commands       |
 
 ### Documentation
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -131,7 +131,13 @@ Tests are located in `src/tests/**/*.test.tsx` using Vitest + jsdom.
 
 Run tests with:
 
-- `nps test.web` - Run all web app tests
+- `nps test.web` / `nps test.web.unit` - Run Vitest unit/component tests
+- `nps test.web.e2e.desktop` - Run Playwright in desktop Chromium
+- `nps test.web.e2e.tablet` - Run Playwright in tablet Chromium
+- `nps test.web.e2e.mobile` - Run Playwright in mobile Chromium
+- `nps test.web.e2e.all` - Run all Playwright viewport projects
+- `PLAYWRIGHT_BASE_URL=https://staging.example.com nps test.web.live` - Run the
+  same Playwright smoke test against an external deployment
 - `nps test.watch` - Watch mode
 - `cd apps/web && pnpm test -- path/to/test.test.tsx` - Single test file
 
@@ -144,3 +150,7 @@ Test utilities:
   `next/router`. Add global mocks here.
 - Server components are async — `await` the component before rendering:
   `render(await RootPage())`, wrapped in `act`/`waitFor` as needed.
+- Local Playwright runs own `WEB_E2E_PORT` (3100 by default) and never reuse an
+  existing server. `nps test.web.live` instead requires `PLAYWRIGHT_BASE_URL`
+  and never starts a local server. Keep every future browser app on a distinct
+  default port so Turbo can run E2E tasks concurrently.

--- a/apps/web/e2e/showcase.spec.ts
+++ b/apps/web/e2e/showcase.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test('navigates to the showcase and updates shared state', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(
+    page.getByRole('heading', { name: 'Build from a stronger starting point.' }),
+  ).toBeVisible();
+
+  await page.getByRole('link', { name: 'Explore showcase' }).click();
+
+  await expect(page).toHaveURL(/\/showcase$/);
+  await expect(page.getByRole('heading', { name: 'Built to be touched.' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Increment' }).click();
+
+  await expect(page.getByLabel('Counter value')).toHaveText('1');
+  await expect(page.getByText('Counter incremented', { exact: true })).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,15 @@
     "lint": "eslint . --max-warnings 0",
     "format": "prettier --write \"src/**/*.{ts,tsx,md,css,json}\"",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:watch": "vitest --watch",
-    "test:ci": "vitest run"
+    "test:ci": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:desktop": "playwright test --project=desktop",
+    "test:e2e:tablet": "playwright test --project=tablet",
+    "test:e2e:mobile": "playwright test --project=mobile",
+    "test:e2e:all": "playwright test --project=desktop --project=tablet --project=mobile",
+    "test:live": "playwright test --config=playwright.live.config.ts"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
@@ -29,6 +36,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^15.1.5",
+    "@playwright/test": "^1.61.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,3 @@
+import { createPlaywrightConfig } from './playwright.shared';
+
+export default createPlaywrightConfig();

--- a/apps/web/playwright.live.config.ts
+++ b/apps/web/playwright.live.config.ts
@@ -1,0 +1,3 @@
+import { createPlaywrightConfig } from './playwright.shared';
+
+export default createPlaywrightConfig({ live: true });

--- a/apps/web/playwright.shared.ts
+++ b/apps/web/playwright.shared.ts
@@ -1,0 +1,72 @@
+import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test';
+
+interface PlaywrightConfigOptions {
+  live?: boolean;
+}
+
+export const createPlaywrightConfig = ({
+  live = false,
+}: PlaywrightConfigOptions = {}): PlaywrightTestConfig => {
+  const port = live ? undefined : Number(process.env.WEB_E2E_PORT ?? 3100);
+  const externalBaseURL = live ? process.env.PLAYWRIGHT_BASE_URL : undefined;
+
+  if (live && !externalBaseURL) {
+    throw new Error('PLAYWRIGHT_BASE_URL is required for live tests.');
+  }
+
+  if (!live && (!Number.isInteger(port) || port! < 1 || port! > 65_535)) {
+    throw new Error('WEB_E2E_PORT must be a valid TCP port.');
+  }
+
+  const baseURL = live ? externalBaseURL! : `http://127.0.0.1:${port}`;
+  const reportFolder = live ? 'playwright-live-report' : 'playwright-report';
+
+  return defineConfig({
+    testDir: './e2e',
+    outputDir: live ? './live-test-results' : './test-results',
+    fullyParallel: true,
+    forbidOnly: Boolean(process.env.CI),
+    retries: process.env.CI ? 2 : 0,
+    reporter: process.env.CI
+      ? [['line'], ['html', { open: 'never', outputFolder: reportFolder }]]
+      : [['html', { open: 'never', outputFolder: reportFolder }]],
+    use: {
+      baseURL,
+      screenshot: 'only-on-failure',
+      trace: 'on-first-retry',
+      video: 'retain-on-failure',
+    },
+    projects: [
+      {
+        name: 'desktop',
+        use: {
+          ...devices['Desktop Chrome'],
+          viewport: { width: 1280, height: 720 },
+        },
+      },
+      {
+        name: 'tablet',
+        use: {
+          browserName: 'chromium',
+          viewport: { width: 768, height: 1024 },
+          hasTouch: true,
+          isMobile: true,
+        },
+      },
+      {
+        name: 'mobile',
+        use: {
+          ...devices['Pixel 7'],
+        },
+      },
+    ],
+    webServer: live
+      ? undefined
+      : {
+          command: `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
+          url: baseURL,
+          reuseExistingServer: false,
+          timeout: 120_000,
+        },
+  });
+};

--- a/docs/github-actions/tests.md
+++ b/docs/github-actions/tests.md
@@ -22,9 +22,10 @@ changed.
 2. **Filter**: Detect application, package, workflow, and root toolchain changes
 3. **Setup**: Install Node.js 24.x, cache dependencies, lint, and typecheck
 4. **Prepare**: Prune monorepo and install dependencies (CI mode)
-5. **Build**: Build the application
-6. **Test**: Run test suite
-7. **Required checks**: Aggregate required jobs into one Ruleset-compatible result
+5. **Build**: Build the application for unit/component tests
+6. **Test**: Run the unit/component test suite
+7. **E2E**: Install Chromium, build through Turbo, and run Playwright
+8. **Required checks**: Aggregate required jobs into one Ruleset-compatible result
 
 ### Job Structure
 
@@ -34,6 +35,7 @@ changed.
 | changes         | Detect file changes in relevant paths     | Always runs              |
 | setup           | Install, lint, and typecheck              | Runs if changes detected |
 | test            | Build and test the application            | Runs if setup succeeds   |
+| e2e             | Run Playwright against the built web app  | Runs for web changes     |
 | Required checks | Aggregate the required results for `main` | Always runs              |
 
 ### Change Detection
@@ -62,7 +64,17 @@ For each affected application/package, the test job then runs:
    - Builds the target application/package
 
 3. **Test (CI)**: `nps test.ci.{target}`
-   - Runs test suite for the target
+   - Runs the unit/component test suite for the target
+
+The E2E job independently prunes the web workspace, installs Chromium, and runs
+`nps test.ci.web.e2e.all`. Turbo builds the web app before Playwright and then
+runs the desktop, tablet, and mobile Chromium projects. If E2E fails, the job
+uploads `web-playwright-artifacts` containing the HTML report, screenshots,
+videos, and traces that Playwright produced.
+
+The `Required checks` job requires both the unit/component job and the E2E job
+to succeed when web paths changed. Live tests against external deployments are
+opt-in and are never part of this workflow.
 
 ### Caching Strategy
 

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 const webPath = path.resolve(__dirname, "apps/web");
 
-const ciWebPath = path.resolve(__dirname, "out/apps/web");
+const ciPath = path.resolve(__dirname, "out");
 
 module.exports = {
   scripts: {
@@ -52,13 +52,35 @@ module.exports = {
       },
     },
     test: {
-      default: `nps test.scripts && nps test.web`,
+      default: `nps test.scripts && npx turbo run test`,
       scripts: `node --test scripts/tests/*.test.mjs`,
-      web: `cd ${webPath} && pnpm test`,
+      e2e: `npx turbo run test:e2e`,
+      web: {
+        default: `nps test.web.unit`,
+        unit: `npx turbo run test --filter=web`,
+        e2e: {
+          default: `nps test.web.e2e.all`,
+          desktop: `npx turbo run test:e2e --filter=web -- --project=desktop`,
+          tablet: `npx turbo run test:e2e --filter=web -- --project=tablet`,
+          mobile: `npx turbo run test:e2e --filter=web -- --project=mobile`,
+          all: `npx turbo run test:e2e --filter=web`,
+        },
+        live: `npx turbo run test:live --filter=web`,
+      },
       ci: {
         default: `nps test.ci.scripts && nps test.ci.web`,
         scripts: `node --test scripts/tests/*.test.mjs`,
-        web: `cd ${ciWebPath} && pnpm test:ci`,
+        web: {
+          default: `nps test.ci.web.unit`,
+          unit: `cd ${ciPath} && pnpm exec turbo run test:ci --filter=web`,
+          e2e: {
+            default: `nps test.ci.web.e2e.all`,
+            desktop: `cd ${ciPath} && pnpm exec turbo run test:e2e --filter=web -- --project=desktop`,
+            tablet: `cd ${ciPath} && pnpm exec turbo run test:e2e --filter=web -- --project=tablet`,
+            mobile: `cd ${ciPath} && pnpm exec turbo run test:e2e --filter=web -- --project=mobile`,
+            all: `cd ${ciPath} && pnpm exec turbo run test:e2e --filter=web`,
+          },
+        },
       },
       watch: {
         default: `nps test.watch.web`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,13 +77,13 @@ importers:
         version: 0.7.1
       next:
         specifier: ^16.2.3
-        version: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nextjs-toploader:
         specifier: ^3.9.17
-        version: 3.9.17(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 3.9.17(next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.1
         version: 19.2.7
@@ -97,6 +97,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^15.1.5
         version: 15.5.19
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1
@@ -1214,6 +1217,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3319,6 +3327,11 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4508,6 +4521,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -6517,6 +6540,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8680,6 +8707,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9533,7 +9563,7 @@ snapshots:
     dependencies:
       enhanced-resolve: 5.24.0
 
-  next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -9552,14 +9582,15 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.9
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
+      '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-toploader@3.9.17(next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  nextjs-toploader@3.9.17(next@16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      next: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 19.2.7
@@ -9812,6 +9843,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "lint": {
       "cache": false
@@ -25,8 +25,20 @@
       "dependsOn": ["build"],
       "persistent": true
     },
+    "test": {
+      "cache": false
+    },
     "test:ci": {
       "cache": false
+    },
+    "test:e2e": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "passThroughEnv": ["CI", "WEB_E2E_PORT"]
+    },
+    "test:live": {
+      "cache": false,
+      "passThroughEnv": ["CI", "PLAYWRIGHT_BASE_URL"]
     }
   }
 }


### PR DESCRIPTION
## Overview

Add a shared Turbo test contract and Playwright foundation so workspace apps can run unit and E2E tasks in parallel without sharing ports or external resources.

## Changes

### Parallel test orchestration

- Add Turbo tasks for unit, E2E, and opt-in live tests.
- Route the public nps commands through Turbo while preserving unit-test defaults.
- Cache Next.js build output required by downstream E2E tasks.

### Playwright web coverage

- Add desktop, tablet, and mobile Chromium projects.
- Cover navigation, Redux state updates, and toast feedback with a smoke test.
- Isolate local E2E on a dedicated port and separate external live-test execution.

### CI and documentation

- Run Playwright in a dedicated required CI job against a pruned workspace.
- Upload reports, screenshots, videos, and traces when E2E fails.
- Document command conventions, resource isolation, and live-test usage.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [x] Environment variable changes
- [ ] None (Code cleanup)

## Testing

<details>
  <summary>nps lint / typecheck / test</summary>

- `nps lint`
- `nps typecheck`
- `nps test`

All passed.
</details>

<details>
  <summary>nps test.web.e2e.all</summary>

Desktop, tablet, and mobile Chromium projects passed locally and in the pruned CI workspace.
</details>

<details>
  <summary>nps test.web.live</summary>

The external URL flow passed in all three viewport projects. Missing `PLAYWRIGHT_BASE_URL` fails before execution as intended.
</details>

## Screenshots

Not applicable. This change does not modify the rendered UI.

## Notes

- Live tests remain opt-in and are excluded from required CI.
- Future workspace apps can participate by defining `test`, `test:ci`, and `test:e2e` package scripts and isolating their runtime resources.
