### PR TITLE
Cache pnpm downloads in a lockfile-only Docker layer

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -29,13 +29,23 @@ WORKDIR /app
 # Enable Corepack so the pinned pnpm version is used
 RUN corepack enable
 
-# Copy the pruned package.json files, lockfile and pnpm-workspace.yaml.
+# Copy only the files `pnpm fetch` depends on: the lockfile, the workspace
+# layout and the root package.json (Corepack reads its packageManager field).
 # `turbo prune --docker` places pnpm-lock.yaml and pnpm-workspace.yaml in out/json.
+COPY --from=builder /app/out/json/package.json /app/out/json/pnpm-lock.yaml /app/out/json/pnpm-workspace.yaml ./
+
+# Populate the pnpm store from the lockfile alone, so this layer stays cached
+# as long as pnpm-lock.yaml is unchanged (e.g. across version bumps and
+# package.json script edits).
+RUN pnpm fetch
+
+# Copy the pruned package.json files of the isolated subworkspace
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/turbo.json ./turbo.json
 
-# Install dependencies (dev deps included; required by the build stage)
-RUN pnpm install --frozen-lockfile
+# Install dependencies from the pre-populated store, without network access
+# (dev deps included; required by the build stage)
+RUN pnpm install --frozen-lockfile --offline
 
 ###############################################################################
 # Sourcer stage: Build the application                                        #


### PR DESCRIPTION
## Overview

The web Dockerfile's installer stage copied all pruned `package.json` files before `pnpm install`, so any manifest edit (version bump, script change) invalidated the layer and re-downloaded every package — even when `pnpm-lock.yaml` was unchanged. This wastes time and defeats the `type=gha` BuildKit cache on CI.

## Changes

- ### Split dependency download into a lockfile-only layer
  - Copy only `pnpm-lock.yaml`, `pnpm-workspace.yaml` and the root `package.json` (Corepack needs its `packageManager` field), then run `pnpm fetch` to populate the store from the lockfile alone
  - Copy the remaining pruned manifests afterwards and run `pnpm install --frozen-lockfile --offline`
  - The download layer now stays cached as long as the lockfile is unchanged; manifest-only edits re-run just the offline install

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [x] Configuration changes

## Testing

<details>
  <summary>docker build --target installer -f apps/web/Dockerfile .</summary>

Full build succeeds (`pnpm fetch` + offline install). Rebuilding after a simulated version bump of `apps/web/package.json`:

```
#14 [installer 5/8] RUN pnpm fetch
#14 CACHED
#15 [installer 6/8] COPY --from=builder /app/out/json/ .
#16 [installer 7/8] COPY --from=builder /app/turbo.json ./turbo.json
#17 [installer 8/8] RUN pnpm install --frozen-lockfile --offline
```

Only the offline install re-runs; the download layer stays cached.

</details>

## Screenshots

None (no UI changes).
