### PR TITLE
Add project setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,20 @@ pnpm install
 pnpm add -g nps
 ```
 
-3. **Configure GitHub**
+3. **Initialize the project**
+
+Replace the starter metadata and choose how the derived project is licensed:
+
+```sh
+nps setup.project
+```
+
+The default private/commercial profile marks the project as `UNLICENSED`,
+replaces the root license with an all-rights-reserved notice, and preserves the
+starter's MIT license under `LICENSES/`. See
+[Project Setup](docs/setup-project.md) for dry-run and non-interactive usage.
+
+4. **Configure GitHub**
 
 Preview and apply the starter's repository settings, Actions permissions,
 labels, and `main` protection:
@@ -108,7 +121,7 @@ nps setup.github
 See [GitHub Repository Setup](docs/github-actions/setup-github.md) for
 non-interactive setup and secret management.
 
-4. **Configure local environment**
+5. **Configure local environment**
 
 Copy the example env file and fill in the values you need for local
 development:
@@ -117,7 +130,7 @@ development:
 cp apps/web/.env.example apps/web/.env   # BASE_URL, LOG_LEVEL (optional)
 ```
 
-5. **Run Development Server**
+6. **Run Development Server**
 
 ```sh
 nps dev
@@ -184,6 +197,7 @@ list.
 | `nps test.web.e2e.all`     | Run web E2E tests at every viewport         |
 | `nps test.web.live`        | Run web E2E tests against an external URL   |
 | `nps test.watch`           | Run web app tests in watch mode             |
+| `nps setup.project`        | Initialize project metadata and licensing   |
 | `nps setup.github`         | Configure GitHub repository settings        |
 | `nps setup.github.secrets` | Configure Repository or Environment secrets |
 | `nps docker.build.web`     | Build the web Docker image                  |

--- a/docs/setup-project.md
+++ b/docs/setup-project.md
@@ -1,0 +1,94 @@
+# Project Setup
+
+**Command**: `nps setup.project`
+
+Use project setup once after creating a repository from this starter. It
+replaces starter-specific metadata and makes the derived project's licensing
+intent explicit.
+
+## Interactive Setup
+
+Run the setup wizard from the repository root:
+
+```sh
+nps setup.project
+```
+
+The wizard asks for:
+
+- Project name and description
+- Author and copyright holder
+- Project type: private/commercial, open source, or reusable starter
+- License for open source projects and starters: MIT or Apache-2.0
+
+Every run displays the planned metadata and file changes before confirmation.
+Confirmation defaults to no.
+
+## Project Types
+
+| Type               | Package license | Root license                  |
+| ------------------ | --------------- | ----------------------------- |
+| Private/commercial | `UNLICENSED`    | All rights reserved           |
+| Open source        | `MIT` or `Apache-2.0` | Selected standard license |
+| Reusable starter   | `MIT` or `Apache-2.0` | Selected standard license |
+
+The root package remains `private: true` for every type. That setting prevents
+accidental npm publication; it does not determine the source-code license.
+
+When setup replaces an MIT root license, it preserves the original text under
+`LICENSES/<original-project>-MIT.txt`. The private license excludes components
+identified in that directory from its proprietary terms. Apache-2.0 setup also
+creates a project `NOTICE` file.
+
+## Dry Run
+
+Pass all project values to preview a non-interactive setup:
+
+```sh
+nps "setup.project --kind private --name example-app --description 'Example application' --author craftsamo --copyright-holder craftsamo --dry-run --yes"
+```
+
+`--dry-run` never writes files. In a terminal, missing values are collected
+interactively. Non-interactive writes require `--yes` and complete metadata.
+
+## Non-Interactive Setup
+
+Use `--yes` only when all required project values are supplied:
+
+```sh
+nps "setup.project --kind private --name example-app --description 'Example application' --author craftsamo --copyright-holder craftsamo --yes"
+```
+
+For an Apache-2.0 open source project:
+
+```sh
+nps "setup.project --kind oss --license Apache-2.0 --name example-app --description 'Example application' --author craftsamo --copyright-holder craftsamo --yes"
+```
+
+Supported arguments:
+
+| Argument                    | Values                              |
+| --------------------------- | ----------------------------------- |
+| `--kind`                    | `private`, `oss`, `starter`         |
+| `--license`                 | `UNLICENSED`, `MIT`, `Apache-2.0`   |
+| `--name`                    | Lowercase npm-compatible name       |
+| `--description`             | Non-empty project description       |
+| `--author`                  | Package author                       |
+| `--copyright-holder`        | License copyright holder             |
+| `--year`                    | Four-digit year; current year by default |
+| `--dry-run`                 | Preview without writing files        |
+| `--yes`                     | Skip confirmation; requires metadata |
+
+Private projects only accept `UNLICENSED`. Open source projects and reusable
+starters only accept MIT or Apache-2.0.
+
+## Safety
+
+Setup stops before prompting or writing when `package.json`, `README.md`,
+`LICENSE`, `NOTICE`, or `LICENSES/` contains uncommitted changes. Existing
+notice files are never overwritten with different content. Writes use a
+temporary file and rename within the destination directory.
+
+The command does not change Git history, remotes, GitHub settings, workspace
+package names, or application-specific configuration. Review third-party code
+and dependency license obligations separately before distributing a product.

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -8,6 +8,7 @@ module.exports = {
   scripts: {
     link: `node scripts/link-agent-skills.mjs`,
     setup: {
+      project: `node scripts/setup/project/index.mts`,
       github: {
         default: `node scripts/setup/github/repository.mts`,
         secrets: `node scripts/setup/github/secrets.mts`,

--- a/scripts/setup/project/apache-license.mts
+++ b/scripts/setup/project/apache-license.mts
@@ -1,0 +1,202 @@
+export const APACHE_LICENSE = `Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include the
+      brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+`;

--- a/scripts/setup/project/files.mts
+++ b/scripts/setup/project/files.mts
@@ -1,0 +1,129 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export interface FileEntry {
+  path: string;
+  content: string;
+}
+
+export interface FileOperations {
+  exists(filePath: string): boolean;
+  read(filePath: string): string;
+  mkdir(directoryPath: string): void;
+  write(filePath: string, content: string): void;
+  rename(from: string, to: string): void;
+  remove(filePath: string): void;
+  warn(message: string): void;
+}
+
+interface StagedFile {
+  target: string;
+  temporary: string;
+  backup: string;
+  hadOriginal: boolean;
+  installed: boolean;
+}
+
+export const nodeFileOperations: FileOperations = {
+  exists: existsSync,
+  read: (filePath) => readFileSync(filePath, "utf8"),
+  mkdir: (directoryPath) => mkdirSync(directoryPath, { recursive: true }),
+  write: (filePath, content) => writeFileSync(filePath, content, "utf8"),
+  rename: renameSync,
+  remove: (filePath) => rmSync(filePath, { force: true }),
+  warn: (message) => console.warn(message),
+};
+
+export function applyFileTransaction(
+  root: string,
+  entries: FileEntry[],
+  operations: FileOperations = nodeFileOperations,
+): void {
+  const changed = entries.filter(({ path: relativePath, content }) => {
+    const target = path.join(root, relativePath);
+    return !operations.exists(target) || operations.read(target) !== content;
+  });
+  const staged: StagedFile[] = [];
+
+  try {
+    for (const [index, { path: relativePath, content }] of changed.entries()) {
+      const target = path.join(root, relativePath);
+      operations.mkdir(path.dirname(target));
+      const temporary = `${target}.setup-project-${process.pid}-${index}`;
+      const backup = `${temporary}.backup`;
+      if (operations.exists(backup)) {
+        throw new Error(`Refusing to overwrite stale backup ${backup}.`);
+      }
+      operations.write(temporary, content);
+      staged.push({
+        target,
+        temporary,
+        backup,
+        hadOriginal: false,
+        installed: false,
+      });
+    }
+    for (const file of staged) {
+      if (operations.exists(file.target)) {
+        operations.rename(file.target, file.backup);
+        file.hadOriginal = true;
+      }
+      operations.rename(file.temporary, file.target);
+      file.installed = true;
+    }
+  } catch (error) {
+    const rollbackErrors: string[] = [];
+    for (const file of [...staged].reverse()) {
+      try {
+        if (file.installed) operations.remove(file.target);
+        if (file.hadOriginal && operations.exists(file.backup)) {
+          operations.rename(file.backup, file.target);
+        }
+      } catch (rollbackError) {
+        rollbackErrors.push(
+          rollbackError instanceof Error
+            ? rollbackError.message
+            : String(rollbackError),
+        );
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)} Rollback failed: ${rollbackErrors.join("; ")}`,
+      );
+    }
+    throw error;
+  } finally {
+    for (const file of staged) {
+      try {
+        operations.remove(file.temporary);
+      } catch (error) {
+        operations.warn(
+          `Could not remove temporary file ${file.temporary}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  const cleanupErrors: string[] = [];
+  for (const file of staged) {
+    try {
+      operations.remove(file.backup);
+    } catch (error) {
+      cleanupErrors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+  if (cleanupErrors.length > 0) {
+    operations.warn(
+      `Project files were updated, but backup cleanup failed: ${cleanupErrors.join("; ")}`,
+    );
+  }
+}

--- a/scripts/setup/project/index.mts
+++ b/scripts/setup/project/index.mts
@@ -1,0 +1,284 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+import type { Interface } from "node:readline/promises";
+
+import { applyFileTransaction } from "./files.mts";
+import {
+  buildProjectPlan,
+  defaultLicense,
+  parseArguments,
+  resolveAnswers,
+} from "./policy.mts";
+import type {
+  ProjectAnswers,
+  ProjectArguments,
+  ProjectKind,
+  ProjectLicense,
+  ProjectPlan,
+  RootPackage,
+} from "./policy.mts";
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+const guardedPaths = [
+  "package.json",
+  "README.md",
+  "LICENSE",
+  "NOTICE",
+  "LICENSES",
+];
+
+async function ask(
+  question: string,
+  defaultValue: string,
+  readline: Interface,
+): Promise<string> {
+  const suffix = defaultValue ? ` [${defaultValue}]` : "";
+  const answer = (await readline.question(`${question}${suffix}: `)).trim();
+  return answer || defaultValue;
+}
+
+async function confirm(
+  question: string,
+  defaultValue: boolean,
+  readline: Interface,
+): Promise<boolean> {
+  const hint = defaultValue ? "Y/n" : "y/N";
+  const answer = (await readline.question(`${question} [${hint}]: `))
+    .trim()
+    .toLowerCase();
+  if (!answer) return defaultValue;
+  return answer === "y" || answer === "yes";
+}
+
+async function collectAnswers(
+  args: ProjectArguments,
+  currentPackage: RootPackage,
+  readline: Interface,
+): Promise<ProjectAnswers> {
+  const kind = args.kind ?? (await chooseKind(readline));
+  const name =
+    args.name ??
+    (await ask("Project name", path.basename(repositoryRoot), readline));
+  const description =
+    args.description ?? (await ask("Description", "", readline));
+  const gitAuthor = runGit(["config", "user.name"], true);
+  const author =
+    args.author ??
+    (await ask("Author", gitAuthor || currentPackage.author || "", readline));
+  const copyrightHolder =
+    args.copyrightHolder ??
+    (await ask("Copyright holder", author, readline));
+  const license =
+    args.license ??
+    (kind === "private" ? defaultLicense(kind) : await chooseLicense(readline));
+
+  return resolveAnswers({
+    kind,
+    license,
+    name,
+    description,
+    author,
+    copyrightHolder,
+    year: args.year ?? new Date().getFullYear(),
+  });
+}
+
+function collectNonInteractiveAnswers(
+  args: ProjectArguments,
+): ProjectAnswers {
+  const required: Array<[string, string | undefined]> = [
+    ["--kind", args.kind],
+    ["--name", args.name],
+    ["--description", args.description],
+    ["--author", args.author],
+    ["--copyright-holder", args.copyrightHolder],
+  ];
+  const missing = required
+    .filter(([, value]) => !value)
+    .map(([flag]) => flag);
+  if (missing.length > 0) {
+    throw new Error(
+      `Non-interactive setup requires ${missing.join(", ")}.`,
+    );
+  }
+
+  return resolveAnswers({
+    kind: args.kind as ProjectKind,
+    ...(args.license ? { license: args.license } : {}),
+    name: args.name as string,
+    description: args.description as string,
+    author: args.author as string,
+    copyrightHolder: args.copyrightHolder as string,
+    year: args.year ?? new Date().getFullYear(),
+  });
+}
+
+async function chooseKind(readline: Interface): Promise<ProjectKind> {
+  console.log("\nProject type");
+  console.log("  1. Private / commercial");
+  console.log("  2. Open source");
+  console.log("  3. Reusable starter");
+  const choice = await ask("Choose a project type", "1", readline);
+  if (choice === "1") return "private";
+  if (choice === "2") return "oss";
+  if (choice === "3") return "starter";
+  throw new Error("Invalid project type selection.");
+}
+
+async function chooseLicense(readline: Interface): Promise<ProjectLicense> {
+  console.log("\nLicense");
+  console.log("  1. MIT");
+  console.log("  2. Apache-2.0");
+  const choice = await ask("Choose a license", "1", readline);
+  if (choice === "1") return "MIT";
+  if (choice === "2") return "Apache-2.0";
+  throw new Error("Invalid license selection.");
+}
+
+function assertTargetFilesClean(): void {
+  const output = runGit(["status", "--porcelain", "--", ...guardedPaths]);
+  if (output) {
+    throw new Error(
+      `Project setup target files have uncommitted changes:\n${output}`,
+    );
+  }
+}
+
+function assertSafeCreates(plan: ProjectPlan): void {
+  for (const file of plan.files) {
+    if (file.path === "README.md" || file.path === "LICENSE") continue;
+    const target = path.join(repositoryRoot, file.path);
+    if (existsSync(target) && readFileSync(target, "utf8") !== file.content) {
+      throw new Error(`Refusing to overwrite existing ${file.path}.`);
+    }
+  }
+}
+
+function printPlan(
+  currentPackage: RootPackage,
+  answers: ProjectAnswers,
+  plan: ProjectPlan,
+): void {
+  console.log("\nProject setup plan");
+  console.log(`  Kind: ${answers.kind}`);
+  printValue("name", currentPackage.name, plan.packageJson.name);
+  printValue(
+    "description",
+    currentPackage.description ?? "",
+    plan.packageJson.description ?? "",
+  );
+  printValue("author", currentPackage.author ?? "", plan.packageJson.author ?? "");
+  printValue(
+    "license",
+    currentPackage.license ?? "",
+    plan.packageJson.license ?? "",
+  );
+  console.log("\nFiles");
+  console.log("  Update: package.json");
+  for (const file of plan.files) {
+    const action = existsSync(path.join(repositoryRoot, file.path))
+      ? "Update"
+      : "Create";
+    console.log(`  ${action}: ${file.path}`);
+  }
+}
+
+function printValue(label: string, current: string, desired: string): void {
+  if (current === desired) console.log(`  ${label}: ${JSON.stringify(current)}`);
+  else {
+    console.log(
+      `  ${label}: ${JSON.stringify(current)} -> ${JSON.stringify(desired)}`,
+    );
+  }
+}
+
+function applyPlan(plan: ProjectPlan): void {
+  applyFileTransaction(repositoryRoot, [
+    {
+      path: "package.json",
+      content: `${JSON.stringify(plan.packageJson, null, 2)}\n`,
+    },
+    ...plan.files,
+  ]);
+}
+
+function runGit(args: string[], allowFailure = false): string {
+  try {
+    return execFileSync("git", args, {
+      cwd: repositoryRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    if (allowFailure) return "";
+    const stderr =
+      typeof error === "object" && error !== null && "stderr" in error
+        ? String(error.stderr).trim()
+        : "";
+    throw new Error(stderr || `git ${args.join(" ")} failed.`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArguments(process.argv.slice(2));
+  assertTargetFilesClean();
+
+  const currentPackage = JSON.parse(
+    readFileSync(path.join(repositoryRoot, "package.json"), "utf8"),
+  ) as RootPackage;
+  const currentReadme = readFileSync(
+    path.join(repositoryRoot, "README.md"),
+    "utf8",
+  );
+  const currentLicense = readFileSync(
+    path.join(repositoryRoot, "LICENSE"),
+    "utf8",
+  );
+  const nonInteractive = args.yes || !process.stdin.isTTY;
+  const readline = nonInteractive
+    ? undefined
+    : createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    const answers = nonInteractive
+      ? collectNonInteractiveAnswers(args)
+      : await collectAnswers(args, currentPackage, readline!);
+    const plan = buildProjectPlan({
+      currentPackage,
+      currentReadme,
+      currentLicense,
+      answers,
+    });
+    assertSafeCreates(plan);
+    printPlan(currentPackage, answers, plan);
+
+    if (args.dryRun) {
+      console.log("\nDry run complete. No files changed.");
+      return;
+    }
+    if (nonInteractive && !args.yes) {
+      throw new Error("Non-interactive setup requires --yes to write files.");
+    }
+    if (!args.yes && !(await confirm("Apply these changes", false, readline!))) {
+      console.log("Project setup cancelled.");
+      return;
+    }
+
+    applyPlan(plan);
+    console.log("\nProject setup complete.");
+  } finally {
+    readline?.close();
+  }
+}
+
+await main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/setup/project/policy.mts
+++ b/scripts/setup/project/policy.mts
@@ -1,0 +1,314 @@
+import path from "node:path";
+import { APACHE_LICENSE } from "./apache-license.mts";
+
+export type ProjectKind = "private" | "oss" | "starter";
+export type ProjectLicense = "UNLICENSED" | "MIT" | "Apache-2.0";
+
+export interface ProjectArguments {
+  dryRun: boolean;
+  yes: boolean;
+  kind?: ProjectKind | undefined;
+  license?: ProjectLicense | undefined;
+  name?: string | undefined;
+  description?: string | undefined;
+  author?: string | undefined;
+  copyrightHolder?: string | undefined;
+  year?: number | undefined;
+}
+
+export interface ProjectAnswers {
+  kind: ProjectKind;
+  license: ProjectLicense;
+  name: string;
+  description: string;
+  author: string;
+  copyrightHolder: string;
+  year: number;
+}
+
+export interface RootPackage {
+  name: string;
+  description?: string;
+  author?: string;
+  license?: string;
+  private?: boolean;
+  [key: string]: unknown;
+}
+
+export interface PlannedFile {
+  path: string;
+  content: string;
+}
+
+export interface ProjectPlan {
+  packageJson: RootPackage;
+  files: PlannedFile[];
+}
+
+const MIT_LICENSE = (year: number, holder: string): string => `MIT License
+
+Copyright (c) ${year} ${holder}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+export function parseArguments(argv: string[]): ProjectArguments {
+  const args: ProjectArguments = { dryRun: false, yes: false };
+  const values = [...argv];
+
+  while (values.length > 0) {
+    const value = values.shift();
+    if (value === "--dry-run") args.dryRun = true;
+    else if (value === "--yes") args.yes = true;
+    else if (value === "--kind")
+      args.kind = requireValue(value, values) as ProjectKind;
+    else if (value === "--license")
+      args.license = requireValue(value, values) as ProjectLicense;
+    else if (value === "--name") args.name = requireValue(value, values);
+    else if (value === "--description")
+      args.description = requireValue(value, values);
+    else if (value === "--author") args.author = requireValue(value, values);
+    else if (value === "--copyright-holder")
+      args.copyrightHolder = requireValue(value, values);
+    else if (value === "--year")
+      args.year = Number(requireValue(value, values));
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+
+  if (args.kind && !isProjectKind(args.kind)) {
+    throw new Error("--kind accepts private, oss, or starter.");
+  }
+  if (args.license && !isProjectLicense(args.license)) {
+    throw new Error("--license accepts UNLICENSED, MIT, or Apache-2.0.");
+  }
+  if (args.year !== undefined && !isValidYear(args.year)) {
+    throw new Error("--year must be a four-digit year.");
+  }
+  if (args.kind && args.license) validateLicense(args.kind, args.license);
+
+  return args;
+}
+
+export function resolveAnswers(
+  values: Omit<ProjectAnswers, "license"> & { license?: ProjectLicense },
+): ProjectAnswers {
+  const license = values.license ?? defaultLicense(values.kind);
+  validateLicense(values.kind, license);
+  validateRequired("Project name", values.name);
+  validatePackageName(values.name);
+  validateRequired("Description", values.description);
+  validateRequired("Author", values.author);
+  validateRequired("Copyright holder", values.copyrightHolder);
+  if (!isValidYear(values.year)) throw new Error("Year must be a four-digit year.");
+  return { ...values, license };
+}
+
+export function buildProjectPlan({
+  currentPackage,
+  currentReadme,
+  currentLicense,
+  answers,
+}: {
+  currentPackage: RootPackage;
+  currentReadme: string;
+  currentLicense: string;
+  answers: ProjectAnswers;
+}): ProjectPlan {
+  const packageJson: RootPackage = {
+    ...currentPackage,
+    name: answers.name,
+    description: answers.description,
+    author: answers.author,
+    license: answers.license,
+    private: true,
+  };
+  const files: PlannedFile[] = [
+    {
+      path: "README.md",
+      content: updateReadme(currentReadme, currentPackage.name, answers),
+    },
+    {
+      path: "LICENSE",
+      content: buildLicense(answers),
+    },
+  ];
+
+  if (currentLicense !== buildLicense(answers) && currentPackage.license === "MIT") {
+    files.push({
+      path: path.posix.join(
+        "LICENSES",
+        `${safeFileName(currentPackage.name)}-MIT.txt`,
+      ),
+      content: ensureTrailingNewline(currentLicense),
+    });
+  }
+  if (answers.license === "Apache-2.0") {
+    files.push({
+      path: "NOTICE",
+      content: `${answers.name}\nCopyright ${answers.year} ${answers.copyrightHolder}\n`,
+    });
+  }
+
+  return { packageJson, files };
+}
+
+export function defaultLicense(kind: ProjectKind): ProjectLicense {
+  return kind === "private" ? "UNLICENSED" : "MIT";
+}
+
+export function buildLicense(answers: ProjectAnswers): string {
+  if (answers.license === "MIT") {
+    return MIT_LICENSE(answers.year, answers.copyrightHolder);
+  }
+  if (answers.license === "Apache-2.0") return APACHE_LICENSE;
+  return `Copyright (c) ${answers.year} ${answers.copyrightHolder}. All rights reserved.
+
+Except for components identified in the LICENSES directory, this software is
+proprietary and confidential. Unauthorized copying, distribution,
+modification, or use is prohibited except as permitted by a written agreement
+with the copyright holder.
+`;
+}
+
+export function updateReadme(
+  source: string,
+  sourceName: string,
+  answers: ProjectAnswers,
+): string {
+  const prepared = prepareReadme(source, sourceName, answers.name);
+  const lines = prepared.split("\n");
+  const headingIndex = lines.findIndex((line) => line.startsWith("# "));
+  if (headingIndex === -1) throw new Error("README.md must contain an H1 heading.");
+  lines[headingIndex] = `# ${answers.name}`;
+
+  let descriptionStart = headingIndex + 1;
+  while (lines[descriptionStart] === "") descriptionStart += 1;
+  let descriptionEnd = descriptionStart;
+  while (
+    descriptionEnd < lines.length &&
+    lines[descriptionEnd] !== "" &&
+    !lines[descriptionEnd]?.startsWith("#")
+  ) {
+    descriptionEnd += 1;
+  }
+  lines.splice(descriptionStart, descriptionEnd - descriptionStart, answers.description);
+
+  const updated = lines.join("\n").trimEnd();
+  const licenseSection = `## License\n\n${licenseSummary(answers.license)}`;
+  const licenseHeading = /^## .*License\s*$/m;
+  const match = licenseHeading.exec(updated);
+  if (!match) return `${updated}\n\n${licenseSection}\n`;
+  const remainder = updated.slice(match.index + match[0].length);
+  const nextHeading = /\n## /.exec(remainder);
+  const suffix = nextHeading ? remainder.slice(nextHeading.index).trimEnd() : "";
+  return `${updated.slice(0, match.index).trimEnd()}\n\n${licenseSection}${suffix ? `\n${suffix}` : ""}\n`;
+}
+
+function prepareReadme(
+  source: string,
+  sourceName: string,
+  projectName: string,
+): string {
+  const sourceDirectory = sourceName.split("/").at(-1) as string;
+  const projectDirectory = projectName.split("/").at(-1) as string;
+  let result = source.replaceAll("\r\n", "\n");
+  result = result.replace(
+    /```sh\ngit clone [^\n]+\ncd [^\n]+\n```/,
+    `\`\`\`sh\ngit clone <repository-url>\ncd ${projectDirectory}\n\`\`\``,
+  );
+  result = result.replaceAll(`${sourceDirectory}/`, `${projectDirectory}/`);
+  result = result.replace(/^\| `nps setup\.project`.*\n/gm, "");
+
+  const installationHeading = "### Installation";
+  const installationStart = result.indexOf(installationHeading);
+  if (installationStart === -1) return result;
+  const followingSection = result.indexOf("\n## ", installationStart);
+  const installationEnd = followingSection === -1 ? result.length : followingSection;
+  const installation = result.slice(installationStart, installationEnd);
+  const withoutSetup = installation.replace(
+    /\n\d+\. \*\*Initialize the project\*\*[\s\S]*?(?=\n\d+\. \*\*)/,
+    "",
+  );
+  let step = 0;
+  const renumbered = withoutSetup.replace(/^\d+\. (?=\*\*)/gm, () => {
+    step += 1;
+    return `${step}. `;
+  });
+  return `${result.slice(0, installationStart)}${renumbered}${result.slice(installationEnd)}`.replaceAll(
+    "the starter's repository settings",
+    "the project's repository settings",
+  );
+}
+
+function licenseSummary(license: ProjectLicense): string {
+  if (license === "MIT") {
+    return "This project is licensed under the MIT License. See [LICENSE](LICENSE).";
+  }
+  if (license === "Apache-2.0") {
+    return "This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE).";
+  }
+  return "This project is proprietary software. See [LICENSE](LICENSE). Upstream license notices are preserved in [LICENSES](LICENSES).";
+}
+
+function validateLicense(kind: ProjectKind, license: ProjectLicense): void {
+  if (kind === "private" && license !== "UNLICENSED") {
+    throw new Error("Private projects must use UNLICENSED.");
+  }
+  if (kind !== "private" && license === "UNLICENSED") {
+    throw new Error("Open source projects and starters must use MIT or Apache-2.0.");
+  }
+}
+
+function validatePackageName(name: string): void {
+  if (!/^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/.test(name)) {
+    throw new Error("Project name must be a lowercase npm package name.");
+  }
+}
+
+function validateRequired(label: string, value: string): void {
+  if (!value.trim()) throw new Error(`${label} is required.`);
+}
+
+function isProjectKind(value: string): value is ProjectKind {
+  return value === "private" || value === "oss" || value === "starter";
+}
+
+function isProjectLicense(value: string): value is ProjectLicense {
+  return value === "UNLICENSED" || value === "MIT" || value === "Apache-2.0";
+}
+
+function isValidYear(year: number): boolean {
+  return Number.isInteger(year) && year >= 1000 && year <= 9999;
+}
+
+function safeFileName(name: string): string {
+  return name.replace(/^@/, "").replaceAll("/", "-");
+}
+
+function ensureTrailingNewline(value: string): string {
+  return `${value.trimEnd()}\n`;
+}
+
+function requireValue(flag: string, values: string[]): string {
+  const value = values.shift();
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}

--- a/scripts/tests/setup-project-cli.test.mjs
+++ b/scripts/tests/setup-project-cli.test.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { buildLicense, resolveAnswers } from "../setup/project/policy.mts";
+
+const currentPackage = {
+  name: "turborepo-starter",
+  description: "Starter description",
+  author: "craftsamo",
+  license: "MIT",
+  version: "0.0.0",
+  private: true,
+};
+const currentLicense = "MIT License\n\nCopyright (c) 2025 craftsamo\n";
+const currentReadme = `# Welcome to the Turborepo Starter!
+
+Starter description that wraps
+over multiple lines.
+
+## Features
+
+- Feature
+
+### Installation
+
+1. **Clone the repository**
+
+\`\`\`sh
+git clone https://github.com/craftsamo/turborepo-starter.git
+cd turborepo-starter
+\`\`\`
+
+2. **Install Dependencies**
+
+3. **Initialize the project**
+
+\`\`\`sh
+nps setup.project
+\`\`\`
+
+4. **Run Development Server**
+
+\`\`\`
+turborepo-starter/
+\`\`\`
+
+## License
+
+Old license text.
+`;
+const projectScriptSource = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../setup/project",
+);
+const metadataArguments = [
+  "--name",
+  "example-app",
+  "--description",
+  "Example application.",
+  "--author",
+  "Example Author",
+  "--copyright-holder",
+  "Example Company",
+  "--year",
+  "2026",
+];
+const privateArguments = ["--kind", "private", ...metadataArguments];
+
+function answers(overrides = {}) {
+  return resolveAnswers({
+    kind: "private",
+    name: "example-app",
+    description: "Example application.",
+    author: "Example Author",
+    copyrightHolder: "Example Company",
+    year: 2026,
+    ...overrides,
+  });
+}
+
+function createFixture(t) {
+  const root = mkdtempSync(path.join(tmpdir(), "setup-project-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const scriptDirectory = path.join(root, "scripts/setup/project");
+  mkdirSync(scriptDirectory, { recursive: true });
+  cpSync(projectScriptSource, scriptDirectory, { recursive: true });
+  writeFileSync(
+    path.join(root, "package.json"),
+    `${JSON.stringify(currentPackage, null, 2)}\n`,
+  );
+  writeFileSync(path.join(root, "README.md"), currentReadme);
+  writeFileSync(path.join(root, "LICENSE"), currentLicense);
+  git(root, ["init"]);
+  git(root, ["config", "user.name", "Test User"]);
+  git(root, ["config", "user.email", "test@example.com"]);
+  git(root, ["add", "."]);
+  git(root, ["commit", "-m", "test fixture"]);
+  return root;
+}
+
+function git(root, args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function runSetup(root, args) {
+  return spawnSync(
+    process.execPath,
+    [path.join(root, "scripts/setup/project/index.mts"), ...args],
+    { cwd: root, encoding: "utf8", input: "" },
+  );
+}
+
+describe("project setup CLI", () => {
+  it("keeps files unchanged during a non-interactive dry run", (t) => {
+    const root = createFixture(t);
+    const before = readFileSync(path.join(root, "package.json"), "utf8");
+    const result = runSetup(root, [...privateArguments, "--dry-run"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Dry run complete\. No files changed\./);
+    assert.equal(readFileSync(path.join(root, "package.json"), "utf8"), before);
+    assert.equal(git(root, ["status", "--porcelain"]), "");
+  });
+
+  it("requires --yes for non-interactive writes", (t) => {
+    const root = createFixture(t);
+    const before = readFileSync(path.join(root, "package.json"), "utf8");
+    const result = runSetup(root, privateArguments);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Non-interactive setup requires --yes/);
+    assert.equal(readFileSync(path.join(root, "package.json"), "utf8"), before);
+    assert.equal(git(root, ["status", "--porcelain"]), "");
+  });
+
+  it("applies private project metadata and licensing", (t) => {
+    const root = createFixture(t);
+    const result = runSetup(root, [...privateArguments, "--yes"]);
+
+    assert.equal(result.status, 0, result.stderr);
+    const packageJson = JSON.parse(
+      readFileSync(path.join(root, "package.json"), "utf8"),
+    );
+    assert.equal(packageJson.name, "example-app");
+    assert.equal(packageJson.license, "UNLICENSED");
+    assert.match(
+      readFileSync(path.join(root, "LICENSE"), "utf8"),
+      /All rights reserved/,
+    );
+    assert.equal(
+      readFileSync(
+        path.join(root, "LICENSES/turborepo-starter-MIT.txt"),
+        "utf8",
+      ),
+      currentLicense,
+    );
+    const readme = readFileSync(path.join(root, "README.md"), "utf8");
+    assert.doesNotMatch(readme, /Initialize the project|turborepo-starter\//);
+  });
+
+  it("applies Apache-2.0 licensing and notice files", (t) => {
+    const root = createFixture(t);
+    const apacheAnswers = answers({ kind: "oss", license: "Apache-2.0" });
+    const result = runSetup(root, [
+      "--kind",
+      "oss",
+      "--license",
+      "Apache-2.0",
+      ...metadataArguments,
+      "--yes",
+    ]);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(
+      readFileSync(path.join(root, "LICENSE"), "utf8"),
+      buildLicense(apacheAnswers),
+    );
+    assert.equal(
+      readFileSync(path.join(root, "NOTICE"), "utf8"),
+      "example-app\nCopyright 2026 Example Company\n",
+    );
+  });
+
+  it("rejects dirty target files", (t) => {
+    const root = createFixture(t);
+    writeFileSync(path.join(root, "README.md"), `${currentReadme}\nChanged.\n`);
+    const result = runSetup(root, [...privateArguments, "--yes"]);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /target files have uncommitted changes/);
+    assert.equal(
+      JSON.parse(readFileSync(path.join(root, "package.json"), "utf8")).name,
+      "turborepo-starter",
+    );
+  });
+
+  it("leaves original files intact when staging cannot complete", (t) => {
+    const root = createFixture(t);
+    writeFileSync(path.join(root, "LICENSES"), "reserved path\n");
+    git(root, ["add", "LICENSES"]);
+    git(root, ["commit", "-m", "reserve licenses path"]);
+    const originalPackage = readFileSync(path.join(root, "package.json"), "utf8");
+    const originalReadme = readFileSync(path.join(root, "README.md"), "utf8");
+    const originalLicense = readFileSync(path.join(root, "LICENSE"), "utf8");
+    const result = runSetup(root, [...privateArguments, "--yes"]);
+
+    assert.equal(result.status, 1);
+    assert.equal(
+      readFileSync(path.join(root, "package.json"), "utf8"),
+      originalPackage,
+    );
+    assert.equal(readFileSync(path.join(root, "README.md"), "utf8"), originalReadme);
+    assert.equal(readFileSync(path.join(root, "LICENSE"), "utf8"), originalLicense);
+    assert.equal(
+      readdirSync(root).some((entry) => entry.includes(".setup-project-")),
+      false,
+    );
+    assert.equal(git(root, ["status", "--porcelain"]), "");
+  });
+});

--- a/scripts/tests/setup-project-files.test.mjs
+++ b/scripts/tests/setup-project-files.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  applyFileTransaction,
+  nodeFileOperations,
+} from "../setup/project/files.mts";
+
+describe("file transactions", () => {
+  it("rolls back installed files when a later rename fails", (t) => {
+    const root = mkdtempSync(path.join(tmpdir(), "setup-transaction-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    writeFileSync(path.join(root, "first.txt"), "first before\n");
+    writeFileSync(path.join(root, "second.txt"), "second before\n");
+    let renameCount = 0;
+    const operations = {
+      ...nodeFileOperations,
+      rename(from, to) {
+        renameCount += 1;
+        if (renameCount === 4) throw new Error("injected rename failure");
+        nodeFileOperations.rename(from, to);
+      },
+    };
+
+    assert.throws(
+      () =>
+        applyFileTransaction(
+          root,
+          [
+            { path: "first.txt", content: "first after\n" },
+            { path: "second.txt", content: "second after\n" },
+          ],
+          operations,
+        ),
+      /injected rename failure/,
+    );
+    assert.equal(readFileSync(path.join(root, "first.txt"), "utf8"), "first before\n");
+    assert.equal(
+      readFileSync(path.join(root, "second.txt"), "utf8"),
+      "second before\n",
+    );
+  });
+
+  it("keeps installed files when backup cleanup fails", (t) => {
+    const root = mkdtempSync(path.join(tmpdir(), "setup-transaction-"));
+    t.after(() => rmSync(root, { recursive: true, force: true }));
+    writeFileSync(path.join(root, "project.txt"), "before\n");
+    const warnings = [];
+    const operations = {
+      ...nodeFileOperations,
+      remove(filePath) {
+        if (filePath.endsWith(".backup")) {
+          throw new Error("injected cleanup failure");
+        }
+        nodeFileOperations.remove(filePath);
+      },
+      warn(message) {
+        warnings.push(message);
+      },
+    };
+
+    applyFileTransaction(
+      root,
+      [{ path: "project.txt", content: "after\n" }],
+      operations,
+    );
+
+    assert.equal(readFileSync(path.join(root, "project.txt"), "utf8"), "after\n");
+    assert.match(warnings.join("\n"), /backup cleanup failed/);
+  });
+});

--- a/scripts/tests/setup-project-policy.test.mjs
+++ b/scripts/tests/setup-project-policy.test.mjs
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildProjectPlan,
+  defaultLicense,
+  parseArguments,
+  resolveAnswers,
+} from "../setup/project/policy.mts";
+
+const currentPackage = {
+  name: "turborepo-starter",
+  description: "Starter description",
+  author: "craftsamo",
+  license: "MIT",
+  version: "0.0.0",
+  private: true,
+};
+const currentLicense = "MIT License\n\nCopyright (c) 2025 craftsamo\n";
+const currentReadme = `# Welcome to the Turborepo Starter!
+
+Starter description that wraps
+over multiple lines.
+
+## Features
+
+- Feature
+
+### Installation
+
+1. **Clone the repository**
+
+\`\`\`sh
+git clone https://github.com/craftsamo/turborepo-starter.git
+cd turborepo-starter
+\`\`\`
+
+2. **Install Dependencies**
+
+3. **Initialize the project**
+
+\`\`\`sh
+nps setup.project
+\`\`\`
+
+4. **Run Development Server**
+
+\`\`\`
+turborepo-starter/
+\`\`\`
+
+## License
+
+Old license text.
+`;
+
+function answers(overrides = {}) {
+  return resolveAnswers({
+    kind: "private",
+    name: "example-app",
+    description: "Example application.",
+    author: "Example Author",
+    copyrightHolder: "Example Company",
+    year: 2026,
+    ...overrides,
+  });
+}
+
+describe("project setup arguments", () => {
+  it("parses non-interactive project metadata", () => {
+    assert.deepEqual(
+      parseArguments([
+        "--kind",
+        "oss",
+        "--license",
+        "Apache-2.0",
+        "--name",
+        "example-app",
+        "--description",
+        "Example application.",
+        "--author",
+        "Example Author",
+        "--copyright-holder",
+        "Example Company",
+        "--year",
+        "2026",
+        "--dry-run",
+        "--yes",
+      ]),
+      {
+        kind: "oss",
+        license: "Apache-2.0",
+        name: "example-app",
+        description: "Example application.",
+        author: "Example Author",
+        copyrightHolder: "Example Company",
+        year: 2026,
+        dryRun: true,
+        yes: true,
+      },
+    );
+  });
+
+  it("rejects incompatible project kinds and licenses", () => {
+    assert.throws(
+      () => parseArguments(["--kind", "private", "--license", "MIT"]),
+      /must use UNLICENSED/,
+    );
+    assert.throws(
+      () =>
+        resolveAnswers({
+          kind: "oss",
+          license: "UNLICENSED",
+          name: "example-app",
+          description: "Example application.",
+          author: "Example Author",
+          copyrightHolder: "Example Company",
+          year: 2026,
+        }),
+      /must use MIT or Apache-2.0/,
+    );
+  });
+
+  it("defaults private projects to UNLICENSED and public projects to MIT", () => {
+    assert.equal(defaultLicense("private"), "UNLICENSED");
+    assert.equal(defaultLicense("oss"), "MIT");
+    assert.equal(defaultLicense("starter"), "MIT");
+  });
+});
+
+describe("project setup plan", () => {
+  it("builds a private project and preserves the upstream MIT license", () => {
+    const plan = buildProjectPlan({
+      currentPackage,
+      currentReadme,
+      currentLicense,
+      answers: answers(),
+    });
+
+    assert.equal(plan.packageJson.name, "example-app");
+    assert.equal(plan.packageJson.license, "UNLICENSED");
+    assert.equal(plan.packageJson.private, true);
+    assert.match(
+      plan.files.find((file) => file.path === "LICENSE").content,
+      /All rights reserved/,
+    );
+    assert.equal(
+      plan.files.find(
+        (file) => file.path === "LICENSES/turborepo-starter-MIT.txt",
+      ).content,
+      currentLicense,
+    );
+    assert.match(
+      plan.files.find((file) => file.path === "README.md").content,
+      /proprietary software/,
+    );
+    assert.doesNotMatch(
+      plan.files.find((file) => file.path === "README.md").content,
+      /nps setup\.project|turborepo-starter\//,
+    );
+  });
+
+  it("generates a fresh MIT license for an open source project", () => {
+    const plan = buildProjectPlan({
+      currentPackage,
+      currentReadme,
+      currentLicense,
+      answers: answers({ kind: "oss", license: "MIT" }),
+    });
+    const license = plan.files.find((file) => file.path === "LICENSE").content;
+
+    assert.match(license, /^MIT License/);
+    assert.match(license, /Copyright \(c\) 2026 Example Company/);
+  });
+
+  it("generates Apache-2.0 with a project notice", () => {
+    const plan = buildProjectPlan({
+      currentPackage,
+      currentReadme,
+      currentLicense,
+      answers: answers({ kind: "oss", license: "Apache-2.0" }),
+    });
+
+    assert.match(
+      plan.files.find((file) => file.path === "LICENSE").content,
+      /Apache License\n +Version 2\.0, January 2004/,
+    );
+    for (let section = 1; section <= 9; section += 1) {
+      assert.match(
+        plan.files.find((file) => file.path === "LICENSE").content,
+        new RegExp(`\\n   ${section}\\.`),
+      );
+    }
+    assert.match(
+      plan.files.find((file) => file.path === "LICENSE").content,
+      /END OF TERMS AND CONDITIONS[\s\S]*APPENDIX: How to apply/,
+    );
+    assert.equal(
+      plan.files.find((file) => file.path === "NOTICE").content,
+      "example-app\nCopyright 2026 Example Company\n",
+    );
+  });
+});

--- a/scripts/tests/setup-project-readme.test.mjs
+++ b/scripts/tests/setup-project-readme.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { resolveAnswers, updateReadme } from "../setup/project/policy.mts";
+
+const currentReadme = `# Welcome to the Turborepo Starter!
+
+Starter description that wraps
+over multiple lines.
+
+## Features
+
+- Feature
+
+### Installation
+
+1. **Clone the repository**
+
+\`\`\`sh
+git clone https://github.com/craftsamo/turborepo-starter.git
+cd turborepo-starter
+\`\`\`
+
+2. **Install Dependencies**
+
+3. **Initialize the project**
+
+\`\`\`sh
+nps setup.project
+\`\`\`
+
+4. **Run Development Server**
+
+\`\`\`
+turborepo-starter/
+\`\`\`
+
+## License
+
+Old license text.
+`;
+
+function answers(overrides = {}) {
+  return resolveAnswers({
+    kind: "private",
+    name: "example-app",
+    description: "Example application.",
+    author: "Example Author",
+    copyrightHolder: "Example Company",
+    year: 2026,
+    ...overrides,
+  });
+}
+
+describe("README updates", () => {
+  it("updates the heading, description, and license section", () => {
+    const result = updateReadme(currentReadme, "turborepo-starter", answers());
+
+    assert.match(result, /^# example-app\n\nExample application\./);
+    assert.match(result, /## Features\n\n- Feature/);
+    assert.match(
+      result,
+      /git clone <repository-url>\ncd example-app/,
+    );
+    assert.doesNotMatch(result, /Initialize the project|nps setup\.project/);
+    assert.match(result, /3\. \*\*Run Development Server\*\*/);
+    assert.match(result, /example-app\//);
+    assert.match(result, /## License\n\nThis project is proprietary software/);
+    assert.doesNotMatch(result, /Old license text/);
+  });
+
+  it("preserves sections following the license section", () => {
+    const result = updateReadme(
+      `${currentReadme}\n## Support\n\nContact support.\n`,
+      "turborepo-starter",
+      answers({ kind: "oss", license: "MIT" }),
+    );
+
+    assert.match(result, /## License\n\nThis project is licensed under the MIT/);
+    assert.match(result, /## Support\n\nContact support\./);
+  });
+
+  it("removes setup-only guidance from the real starter README", () => {
+    const realReadme = readFileSync(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../README.md"),
+      "utf8",
+    );
+    const result = updateReadme(
+      realReadme,
+      "turborepo-starter",
+      answers(),
+    );
+
+    assert.doesNotMatch(result, /nps setup\.project|turborepo-starter\//);
+    assert.doesNotMatch(result, /the starter's repository settings/);
+    assert.match(result, /the project's repository settings/);
+  });
+
+  it("uses the repository directory for scoped package names", () => {
+    const result = updateReadme(
+      currentReadme,
+      "@craftsamo/turborepo-starter",
+      answers({ name: "@acme/example-app" }),
+    );
+
+    assert.match(result, /cd example-app/);
+    assert.match(result, /example-app\//);
+    assert.doesNotMatch(result, /cd @acme\/example-app/);
+  });
+});


### PR DESCRIPTION
## Overview

Add a safe project initialization command for repositories derived from this starter. The command replaces starter metadata, applies an explicit licensing profile, and preserves upstream license notices.

## Changes

- ### Add project setup workflows
  - Support private/commercial, MIT, and Apache-2.0 project profiles
  - Provide interactive, non-interactive, and dry-run execution modes
  - Validate metadata and require explicit confirmation before writing

- ### Protect project files during initialization
  - Stage all output before installation and roll back partial failures
  - Refuse dirty target files and conflicting notice files
  - Preserve the original MIT license under `LICENSES/`

- ### Document and verify setup behavior
  - Expose the command as `nps setup.project`
  - Document supported arguments, licensing behavior, and safety constraints
  - Cover policies, README conversion, file transactions, and real CLI execution

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

<details>
  <summary>nps lint</summary>

Passed with no warnings.

</details>

<details>
  <summary>nps typecheck</summary>

Passed for scripts, apps, and packages.

</details>

<details>
  <summary>nps test</summary>

Passed all 51 tests: 44 script tests and 7 web tests.

</details>

## Screenshots

Not applicable. No UI changes.

## Notes

The generated license selection does not replace a project-specific legal review. Third-party dependency obligations remain outside the setup command.
