### PR TITLE
Add Grok Build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ yarn-error.log*
 /.codex/agents
 /.gemini/agents
 /.github/agents
+/.grok/agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ conflict", or "fork" alone are not sufficient to trigger `sync-upstream`.
 ## Agent Routing
 
 The repository defines shared subagents in `.opencode/agents/`, mirrored to
-tool-native definitions (Claude Code, Codex CLI, Gemini CLI, Copilot CLI) on
-install.
+tool-native definitions (Claude Code, Codex CLI, Gemini CLI, Copilot CLI, Grok
+Build) on install, including `.grok/agents/`.
 
 Use `reviewer` for a broad read-only scan of a change before commit or PR:
 project conventions, AGENTS.md violations, obvious bugs, missing tests, and

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ configurations.
 - **Testing**: Vitest setup for unit and integration tests
 - **Git Workflow**: Commitizen and Commitlint for conventional commits
 - **AI Agent Skills**: on-demand skills in `.opencode/skills/`, shared across
-  Claude Code, Codex, Gemini CLI, and Copilot. Tool-native skill links
-  (`.agents/skills/`, `.claude/skills/`) are generated on `pnpm install`
-  (POSIX symlink / Windows junction, no admin needed); per-package `AGENTS.md`
-  is auto-loaded as instructions
+  Claude Code, Codex, Gemini CLI, Copilot, and Grok Build. Tool-native skill
+  links (`.agents/skills/`, `.claude/skills/`) and agent definitions
+  (`.grok/agents/` from canonical `.opencode/agents/`) are generated on
+  `pnpm install` (POSIX symlink / Windows junction, no admin needed);
+  per-package `AGENTS.md` is auto-loaded as instructions
 - **Best Practices**: Optimized configurations and development guidelines
 
 ## 🛠 Tech Stack

--- a/scripts/sync-agents.mjs
+++ b/scripts/sync-agents.mjs
@@ -10,6 +10,7 @@
 //     -> .claude/agents/<name>.md          Claude Code (MD + frontmatter)
 //     -> .codex/agents/<name>.toml         Codex CLI (TOML)
 //     -> .gemini/agents/<name>.md          Gemini CLI (MD + frontmatter)
+//     -> .grok/agents/<name>.md            Grok Build (MD + frontmatter)
 //     -> .github/agents/<name>.agent.md    Copilot CLI (MD + frontmatter)
 //
 // The conversion is intentionally lossy: opencode's per-glob bash permissions
@@ -63,6 +64,7 @@ function main() {
     { dir: ".claude/agents", ext: ".md", emit: emitClaude },
     { dir: ".codex/agents", ext: ".toml", emit: emitCodex },
     { dir: ".gemini/agents", ext: ".md", emit: emitGemini },
+    { dir: ".grok/agents", ext: ".md", emit: emitGrok },
     { dir: ".github/agents", ext: ".agent.md", emit: emitCopilot },
   ];
 
@@ -333,6 +335,29 @@ function emitGemini(agent) {
     ...(c.bash ? ["run_shell_command"] : []),
     ...(c.webfetch ? ["web_fetch"] : []),
     ...(c.websearch ? ["google_web_search"] : []),
+  ];
+  return frontmatterDocument(
+    {
+      name: agent.name,
+      description: agent.description,
+      tools,
+    },
+    agent.body,
+  );
+}
+
+// --- Grok Build: .grok/agents/<name>.md --------------------------------------
+
+function emitGrok(agent) {
+  const c = agent.capabilities;
+  const tools = [
+    ...(c.read ? ["read_file"] : []),
+    ...(c.grep ? ["grep"] : []),
+    ...(c.glob || c.list ? ["list_dir"] : []),
+    ...(c.edit ? ["search_replace"] : []),
+    ...(c.bash ? ["run_terminal_command"] : []),
+    ...(c.webfetch ? ["web_fetch"] : []),
+    ...(c.websearch ? ["web_search"] : []),
   ];
   return frontmatterDocument(
     {

--- a/scripts/tests/sync-agents.test.mjs
+++ b/scripts/tests/sync-agents.test.mjs
@@ -109,6 +109,42 @@ describe("sync-agents", () => {
     assert.doesNotMatch(grok, /^model:/m);
   });
 
+  it("maps every enabled capability to the complete Grok Build tool allowlist", () => {
+    const allCapabilitiesPath = join(root, ".opencode/agents/all-capabilities.md");
+    writeFileSync(
+      allCapabilitiesPath,
+      `---
+description: "Fixture with every capability enabled."
+permission:
+  read: allow
+  grep: allow
+  glob: allow
+  list: allow
+  edit: allow
+  bash: allow
+  webfetch: allow
+  websearch: allow
+---
+
+All capabilities fixture.
+`,
+    );
+
+    try {
+      runSync(root);
+      const grok = readFileSync(join(root, ".grok/agents/all-capabilities.md"), "utf8");
+      assert.match(
+        grok,
+        /^tools:\n  - read_file\n  - grep\n  - list_dir\n  - search_replace\n  - run_terminal_command\n  - web_fetch\n  - web_search$/m,
+      );
+      assert.equal((grok.match(/^  - list_dir$/gm) ?? []).length, 1);
+      assert.doesNotMatch(grok, /^model:/m);
+    } finally {
+      rmSync(allCapabilitiesPath, { force: true });
+      runSync(root);
+    }
+  });
+
   it("writes generated files read-only so in-place edits fail", () => {
     const filePath = join(root, ".claude/agents/fixture.md");
     assert.equal(statSync(filePath).mode & 0o222, 0, "generated file is writable");

--- a/scripts/tests/sync-agents.test.mjs
+++ b/scripts/tests/sync-agents.test.mjs
@@ -66,6 +66,7 @@ describe("sync-agents", () => {
       ".claude/agents/fixture.md",
       ".codex/agents/fixture.toml",
       ".gemini/agents/fixture.md",
+      ".grok/agents/fixture.md",
       ".github/agents/fixture.agent.md",
     ]) {
       assert.ok(existsSync(join(root, file)), `missing ${file}`);
@@ -98,6 +99,14 @@ describe("sync-agents", () => {
     assert.match(gemini, /- search_file_content/);
     assert.match(gemini, /- run_shell_command/);
     assert.doesNotMatch(gemini, /write_file/);
+  });
+
+  it("maps permissions to Grok Build tool names without model", () => {
+    const grok = readFileSync(join(root, ".grok/agents/fixture.md"), "utf8");
+    assert.match(grok, /^name: fixture$/m);
+    assert.match(grok, /^description: Read-only fixture agent\. Prefer invoking through the task tool\.$/m);
+    assert.match(grok, /^tools:\n  - read_file\n  - grep\n  - list_dir\n  - run_terminal_command$/m);
+    assert.doesNotMatch(grok, /^model:/m);
   });
 
   it("writes generated files read-only so in-place edits fail", () => {
@@ -136,6 +145,7 @@ describe("sync-agents", () => {
 
     assert.ok(!existsSync(join(root, ".claude/agents/fixture.md")));
     assert.ok(!existsSync(join(root, ".codex/agents/fixture.toml")));
+    assert.ok(!existsSync(join(root, ".grok/agents/fixture.md")));
     assert.ok(existsSync(handWritten), "hand-written agent was deleted");
 
     // Restore the fixture for any later assertions.


### PR DESCRIPTION
## Summary

- Add a Grok Build target to `scripts/sync-agents.mjs` that mirrors canonical `.opencode/agents/*.md` definitions into read-only `.grok/agents/*.md` files.
- Translate generic agent capabilities to Grok-native tool names while preserving generated-file markers, stale cleanup, handwritten-file protection, and idempotency.
- Add Grok target/tool-mapping regression coverage and document Grok Build support in README, AGENTS, and `.gitignore`.

## Runtime verification

- `grok inspect --json` with Grok 0.2.106 discovered 3 project agents, 11 project skills through the existing `.agents/skills` link, and the root project instructions.
- A second `node scripts/sync-agents.mjs` run produced no changes; generated Grok agent files were mode 0444.

## Validation

- `node --test scripts/tests/*.test.mjs`: 58 passed, 0 failed
- `node --check scripts/sync-agents.mjs`: passed
- `node --check scripts/tests/sync-agents.test.mjs`: passed
- `git diff --check d8c4987..HEAD`: passed

## Not run

- `nps typecheck`, `nps lint`, and the build were not run because pnpm/nps/node_modules were unavailable in the worktree. No dependencies were installed or changed.