### PR TITLE
Ignore local workflow step outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ yarn-error.log*
 .variables
 .opencode/package-lock.json
 
+# step outputs captured when running a workflow step locally
+# (e.g. GITHUB_OUTPUT=gh_output ./step.sh)
+gh_output
+
 # generated agent-skill links (created by scripts/link-agent-skills.mjs on install)
 /.agents/skills
 /.claude/skills


### PR DESCRIPTION
## What

Add `gh_output` to `.gitignore`, under the existing `# act` block that already
covers local workflow-run artifacts.

```gitignore
# step outputs captured when running a workflow step locally
# (e.g. GITHUB_OUTPUT=gh_output ./step.sh)
gh_output
```

## Why

Several workflows in this repo write to `$GITHUB_OUTPUT`:

- `.github/workflows/get-details.yml`
- `.github/workflows/opencode.yml`
- `.github/workflows/assign-labels.yml`
- `.github/workflows/tests.yml`

When you verify one of those `run` blocks locally, the usual approach is to
point `GITHUB_OUTPUT` at a scratch file:

```bash
export GITHUB_OUTPUT="$dir/gh_output"
```

That file is easy to leave behind in the repo root and it has already been
committed by accident once in a downstream fork. Ignoring it keeps the
artifact out of `git status` and out of future commits.

## Placement

This is deliberately placed in the root starter rather than in a fork:
the workflows that produce the file live here, so every fork inherits both
the cause and the fix via `sync-upstream`.

## Verification

```bash
printf 'details=[]\n' > gh_output
git status --short   # no gh_output entry
rm -f gh_output
```

Nothing else changes; no code, dependency or workflow behaviour is touched.