### PR TITLE
Look up deployment environments by name

### DIFF
--- a/docs/github-actions/setup-github.md
+++ b/docs/github-actions/setup-github.md
@@ -86,8 +86,10 @@ values are entered directly through `gh secret set`; the Node.js setup process
 does not receive or log them.
 
 Existing Environments are offered as choices. A new Environment can be created
-after confirmation. Environment protection rules such as reviewers, deployment
-branches, and wait timers are outside this command's scope.
+after confirmation. Setting protection rules is outside this command's scope,
+but existing ones are preserved: an Environment that already exists is never
+re-sent to the API, so reviewers, deployment branches, and wait timers
+configured elsewhere survive a re-run.
 
 Jobs must declare an Environment to access its secrets:
 

--- a/scripts/setup/github/lib.mts
+++ b/scripts/setup/github/lib.mts
@@ -11,6 +11,12 @@ export interface CommandErrorFields {
 
 export type ApiMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
+export type ApiRequest = <T = unknown>(
+  method: ApiMethod,
+  endpoint: string,
+  body?: unknown,
+) => T | undefined;
+
 export interface RunCommandOptions {
   inherit?: boolean | undefined;
   input?: string | undefined;
@@ -111,6 +117,53 @@ export function getRepositoryName(explicitRepository?: string): string {
     "--jq",
     ".nameWithOwner",
   ]);
+}
+
+/**
+ * Report whether a deployment environment already exists.
+ *
+ * Asks for the single environment by name instead of scanning the environment
+ * list: the list endpoint is paginated, so a repository with more environments
+ * than one page would report an existing environment as missing.
+ */
+export function environmentExists(
+  repository: string,
+  name: string,
+  request: ApiRequest = api,
+): boolean {
+  try {
+    request(
+      "GET",
+      `/repos/${repository}/environments/${encodeURIComponent(name)}`,
+    );
+    return true;
+  } catch (error) {
+    if (error instanceof CommandError && error.httpStatus === 404) return false;
+    throw error;
+  }
+}
+
+/**
+ * Create a deployment environment when it is missing, and return whether it was
+ * created.
+ *
+ * An existing environment is left untouched on purpose. `PUT /environments`
+ * is an upsert whose omitted properties are reset, so re-sending it would strip
+ * the protection rules (required reviewers, wait timer, branch policy) that a
+ * repository administrator configured out of band.
+ */
+export function ensureEnvironment(
+  repository: string,
+  name: string,
+  request: ApiRequest = api,
+): boolean {
+  if (environmentExists(repository, name, request)) return false;
+  request(
+    "PUT",
+    `/repos/${repository}/environments/${encodeURIComponent(name)}`,
+    {},
+  );
+  return true;
 }
 
 export function preflight(explicitRepository?: string): PreflightResult {

--- a/scripts/setup/github/secrets.mts
+++ b/scripts/setup/github/secrets.mts
@@ -6,7 +6,14 @@ import process from "node:process";
 
 import { COPILOT_SECRETS, parseArguments } from "./policy.mts";
 import type { SetupArguments } from "./policy.mts";
-import { api, preflight, repositoryRoot, runCommand } from "./lib.mts";
+import {
+  api,
+  ensureEnvironment,
+  environmentExists,
+  preflight,
+  repositoryRoot,
+  runCommand,
+} from "./lib.mts";
 import type { PreflightResult } from "./lib.mts";
 
 type Repository = PreflightResult["repository"];
@@ -154,13 +161,11 @@ export async function setupSecrets(args: SetupArguments): Promise<void> {
       }
     }
 
-    const environments =
-      target.type === "environment" ? listEnvironments(repository) : [];
-    const environmentExists =
+    const targetEnvironmentExists =
       target.type === "environment" &&
-      environments.some(({ name }) => name === target.name);
+      environmentExists(repository, target.name);
     if (target.type === "environment") {
-      if (!environmentExists) {
+      if (!targetEnvironmentExists) {
         console.log(`Environment will be created: ${target.name}`);
       }
       console.warn(
@@ -169,7 +174,7 @@ export async function setupSecrets(args: SetupArguments): Promise<void> {
     }
 
     const existing =
-      target.type === "environment" && !environmentExists
+      target.type === "environment" && !targetEnvironmentExists
         ? []
         : listSecretNames(repository, target);
     for (const name of names) {
@@ -184,12 +189,8 @@ export async function setupSecrets(args: SetupArguments): Promise<void> {
       console.log("Secret setup cancelled.");
       return;
     }
-    if (target.type === "environment" && !environmentExists) {
-      api<unknown>(
-        "PUT",
-        `/repos/${repository}/environments/${encodeURIComponent(target.name)}`,
-        {},
-      );
+    if (target.type === "environment") {
+      ensureEnvironment(repository, target.name);
     }
     for (const name of names) setSecret(repository, target, name);
     console.log("Secret setup completed.");

--- a/scripts/tests/setup-github.test.mjs
+++ b/scripts/tests/setup-github.test.mjs
@@ -11,6 +11,11 @@ import {
   parseArguments,
   parseLabels,
 } from "../setup/github/policy.mts";
+import {
+  CommandError,
+  ensureEnvironment,
+  environmentExists,
+} from "../setup/github/lib.mts";
 
 describe("parseArguments", () => {
   it("uses interactive repository setup by default", () => {
@@ -327,6 +332,76 @@ describe("labels", () => {
           { name: "💬question", description: "Questions", color: "D876E3" },
         ]),
       /Merge their assignments manually/,
+    );
+  });
+});
+
+describe("deployment environments", () => {
+  const httpError = (status, message) =>
+    new CommandError("gh api", { stderr: `gh: ${message} (HTTP ${status})` });
+
+  const recorder = (respond) => {
+    const calls = [];
+    const request = (method, endpoint, body) => {
+      calls.push({ method, endpoint, body });
+      return respond(method);
+    };
+    return { calls, request };
+  };
+
+  it("creates a missing environment with a single upsert", () => {
+    const { calls, request } = recorder((method) => {
+      if (method === "GET") throw httpError(404, "Not Found");
+      return undefined;
+    });
+
+    assert.equal(ensureEnvironment("owner/repo", "production", request), true);
+    assert.deepEqual(calls, [
+      {
+        method: "GET",
+        endpoint: "/repos/owner/repo/environments/production",
+        body: undefined,
+      },
+      {
+        method: "PUT",
+        endpoint: "/repos/owner/repo/environments/production",
+        body: {},
+      },
+    ]);
+  });
+
+  it("leaves an existing environment untouched so protection rules survive", () => {
+    const { calls, request } = recorder(() => ({ name: "production" }));
+
+    assert.equal(ensureEnvironment("owner/repo", "production", request), false);
+    assert.deepEqual(
+      calls.map(({ method }) => method),
+      ["GET"],
+    );
+  });
+
+  it("propagates a non-404 lookup failure instead of overwriting", () => {
+    const { calls, request } = recorder(() => {
+      throw httpError(403, "Forbidden");
+    });
+
+    assert.throws(
+      () => ensureEnvironment("owner/repo", "production", request),
+      /Forbidden/,
+    );
+    assert.deepEqual(
+      calls.map(({ method }) => method),
+      ["GET"],
+    );
+  });
+
+  it("escapes the environment name in the endpoint path", () => {
+    const { calls, request } = recorder(() => ({}));
+
+    assert.equal(environmentExists("owner/repo", "staging/eu", request), true);
+    assert.equal(
+      calls[0].endpoint,
+      "/repos/owner/repo/environments/staging%2Feu",
     );
   });
 });


### PR DESCRIPTION
## What

Replace the list-based environment existence check in `nps setup.github.secrets`
with a direct lookup, and move it into a reusable `ensureEnvironment` helper.

```ts
// scripts/setup/github/lib.mts
export function ensureEnvironment(
  repository: string,
  name: string,
  request: ApiRequest = api,
): boolean;
```

## Why

The command decided whether a deployment environment already existed by
scanning the environment list:

```ts
api("GET", `/repos/${repository}/environments?per_page=100`);
```

That endpoint is paginated and the call reads a single page. In a repository
with more environments than fit on one page, an existing environment is
reported as missing, and the follow-up branch then runs the create path:

```ts
api("PUT", `/repos/${repository}/environments/${name}`, {});
```

`PUT /environments` is an upsert whose omitted properties are reset, so that
call would strip the reviewers, wait timer and branch policy an administrator
had configured — silently, on a re-run of a command that only meant to make
sure the environment exists.

Asking for the single environment by name removes the page window entirely: a
`404` means missing, anything else means present, and the upsert only ever runs
for an environment that does not exist yet.

## Changes

- **`lib.mts`**: add `environmentExists` and `ensureEnvironment`. Both take an
  injectable request function so the create path and the leave-alone path can
  be tested without touching the network. A non-404 failure propagates instead
  of falling through to the upsert.
- **`secrets.mts`**: use the helper for both the "will be created" notice and
  the create call. The interactive environment menu still lists environments,
  which is unrelated to the existence decision.
- **Docs**: state the guarantee — setting protection rules stays out of scope,
  but existing ones survive a re-run.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [ ] Configuration changes
- [ ] Environment variable changes
- [x] None (Code cleanup)

## Testing

```
$ nps test.scripts
# tests 62
# pass 62
# fail 0

$ nps typecheck.scripts
(exit 0)
```

Four new cases cover the create path, the leave-alone path, a propagated 403,
and endpoint escaping for a name containing `/`.

## Notes

`ensureEnvironment` is the only supported way to create an environment from the
setup scripts now; calling `PUT /environments` directly reintroduces the reset.
