### PR TITLE
Scope the web base URL to the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Copy the example env file and fill in the values you need for local
 development:
 
 ```sh
-cp apps/web/.env.example apps/web/.env   # BASE_URL, LOG_LEVEL (optional)
+cp apps/web/.env.example apps/web/.env   # WEB_BASE_URL, LOG_LEVEL (optional)
 ```
 
 6. **Run Development Server**
@@ -144,10 +144,15 @@ nps dev
 The web app reads runtime configuration from `apps/web/.env`. See
 `apps/web/.env.example` for the full list:
 
-| Variable    | Purpose                                                                                               |
-| ----------- | ----------------------------------------------------------------------------------------------------- |
-| `BASE_URL`  | Base URL used for absolute links, sitemap, robots, and API calls                                      |
-| `LOG_LEVEL` | Logger verbosity: `verbose` / `debug` / `info` / `log` / `warn` / `error` / `fatal` (default: `info`) |
+| Variable       | Purpose                                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------------------- |
+| `WEB_BASE_URL` | Base URL used for absolute links, sitemap, robots, and API calls                                      |
+| `LOG_LEVEL`    | Logger verbosity: `verbose` / `debug` / `info` / `log` / `warn` / `error` / `fatal` (default: `info`) |
+
+An app-specific variable is prefixed with the app directory name, so each app
+under `apps/` gets its own value (`WEB_BASE_URL`, and `<APP>_BASE_URL` for any
+app added later). A variable whose value is meant to be shared across apps,
+such as `LOG_LEVEL`, keeps its bare name.
 
 ### GitHub Actions Variables
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,6 @@
 ## Base URL used for absolute links, sitemap, robots, and API calls.
 ## Defaults to http://localhost when unset (see apps/web/src/app/*).
-BASE_URL=
+WEB_BASE_URL=
 
 ## Logger verbosity: verbose | debug | info | log | warn | error | fatal
 ## Defaults to "info" when unset (see apps/web/src/lib/logger.ts).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -63,9 +63,9 @@ The server will start at `http://localhost:3000`.
 
 ## 🔧 Environment Variables
 
-| Variable   | Default               | Description  |
-| ---------- | --------------------- | ------------ |
-| `BASE_URL` | http://localhost:3000 | API base URL |
+| Variable       | Default               | Description  |
+| -------------- | --------------------- | ------------ |
+| `WEB_BASE_URL` | http://localhost:3000 | API base URL |
 
 ## 📚 Available Commands
 

--- a/apps/web/src/app/global-not-found.tsx
+++ b/apps/web/src/app/global-not-found.tsx
@@ -7,7 +7,7 @@ import { Button } from '@workspace/ui/components/button';
 import { ThemeProvider } from '@/components/Providers';
 import { Center, Container, Heading, HStack, Text, VStack } from '@/components';
 
-const baseUrl = process.env.BASE_URL ?? 'http://localhost';
+const baseUrl = process.env.WEB_BASE_URL ?? 'http://localhost';
 
 const fontSans = Geist({
   subsets: ['latin'],

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Toaster } from '@workspace/ui/components/sonner';
 import '@workspace/ui/globals.css';
 import { ReduxToolProvider, ThemeProvider } from '@/components/Providers';
 
-const baseUrl = process.env.BASE_URL ?? 'http://localhost';
+const baseUrl = process.env.WEB_BASE_URL ?? 'http://localhost';
 const SITE_NAME = 'Turborepo Starter';
 const SITE_DESCRIPTION = 'This is the Turborepo Starter web application.';
 

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-const baseUrl = process.env.BASE_URL ?? 'http://localhost';
+const baseUrl = process.env.WEB_BASE_URL ?? 'http://localhost';
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-const baseUrl = process.env.BASE_URL ?? 'http://localhost';
+const baseUrl = process.env.WEB_BASE_URL ?? 'http://localhost';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -5,7 +5,7 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**"],
-      "env": ["LOG_LEVEL"]
+      "env": ["WEB_BASE_URL", "LOG_LEVEL"]
     },
     "typecheck": {
       "dependsOn": ["^build", "^typecheck"]

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalEnv": ["BASE_URL", "LOG_LEVEL"],
+  "globalEnv": ["WEB_BASE_URL", "LOG_LEVEL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalEnv": ["WEB_BASE_URL", "LOG_LEVEL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## What

Rename `BASE_URL` to `WEB_BASE_URL`, and move it — together with `LOG_LEVEL` —
out of the root `globalEnv` into the web app's `build` task.

## Why

### The name claimed the whole monorepo

`BASE_URL` is read in exactly four places, all of them in the web app:

- `apps/web/src/app/layout.tsx` (`metadataBase`)
- `apps/web/src/app/robots.ts`
- `apps/web/src/app/sitemap.ts`
- `apps/web/src/app/global-not-found.tsx`

It is a per-app value: two apps under `apps/` cannot share one origin. With a
bare name, adding a second app forces either a collision or a naming rule
invented after the fact. Prefixing it with the app directory name settles that
now, while there is exactly one app to migrate.

`LOG_LEVEL` is deliberately left bare. Its value is one a second app would
reasonably share, so the prefix would be noise. The README states the rule so
the next variable does not have to guess.

### `globalEnv` invalidated caches that never read the value

`globalEnv` folds a variable into the cache key of every task in every package.
`LOG_LEVEL` was already declared on the web `build` task, so the entry was also
redundant. Changing either variable busted the `@workspace/*` builds that do
not read them.

Declaring both on the web `build` task fixes the scope:

```
$ WEB_BASE_URL=https://example.test nps build
Tasks:    3 successful, 3 total
Cached:    2 cached, 3 total
```

The two package builds stay cached; only the web build re-runs.

## Changes

- **Rename**: `BASE_URL` to `WEB_BASE_URL` across the four app files,
  `.env.example`, and both READMEs.
- **Convention**: document that an app-specific variable carries the app
  directory name as a prefix, while a variable meant to be shared keeps its
  bare name.
- **Turbo**: drop `globalEnv` from the root config; add `WEB_BASE_URL` next to
  `LOG_LEVEL` on the web `build` task.

The two commits are separable: the rename builds and passes on its own, the
cache scoping is a config-only follow-up.

## Breaking Changes

- [x] Yes
- [ ] No

`BASE_URL` no longer has any effect. Rename it to `WEB_BASE_URL` in
`apps/web/.env` and in any deployment configuration that supplies it.

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [x] Environment variable changes
- [ ] None (Code cleanup)

## Testing

```
$ nps lint          # PASS
$ nps typecheck     # PASS
$ nps build         # PASS
$ nps test.web.unit # PASS
$ nps test.scripts  # 62 pass / 0 fail
```

End-to-end, the renamed variable reaches the build output:

```
$ WEB_BASE_URL=https://example.test nps build
$ cat apps/web/.next/server/app/robots.txt.body
User-Agent: *
Allow: /

Sitemap: https://example.test/sitemap.xml
```

## Notes

The fallback is unchanged: every reader still defaults to `http://localhost`
when the variable is unset, so an environment that never set `BASE_URL` behaves
exactly as before.
