### PR TITLE
Add layout regression testing

### DIFF
--- a/.github/workflows/update-vrt-baselines.yml
+++ b/.github/workflows/update-vrt-baselines.yml
@@ -1,0 +1,67 @@
+name: Update VRT baselines
+
+# Regenerates the visual-regression baseline images on the same platform that
+# compares them (Linux) and opens a PR with the result. Run this after landing
+# an intentional visual change, or once to seed the initial baselines.
+#
+# NOTE: PRs created with the default GITHUB_TOKEN do not trigger the Tests
+# workflow automatically; close/reopen the PR (or push an empty commit) if you
+# need the required checks to run on it.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
+
+jobs:
+  update-baselines:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24.x
+          package-manager-cache: false
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "dir=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - run: pnpm install --frozen-lockfile
+      - name: Build web
+        run: npx turbo run build --filter=web
+      - name: Install Chromium
+        working-directory: apps/web
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Regenerate VRT baselines
+        working-directory: apps/web
+        env:
+          VRT_UPDATE: "1"
+        run: pnpm exec playwright test e2e/vrt.spec.ts --update-snapshots
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: apps/web/e2e/**
+          branch: chore/update-vrt-baselines
+          commit-message: "test(web): update VRT baselines"
+          title: Update VRT baselines
+          body: |
+            Regenerated visual-regression baseline images via the
+            **Update VRT baselines** workflow (Linux/Chromium render).
+
+            Review the image diffs to confirm every change is intentional,
+            then merge to activate them as the new comparison baselines.
+          delete-branch: true

--- a/.opencode/skills/add-e2e-test/SKILL.md
+++ b/.opencode/skills/add-e2e-test/SKILL.md
@@ -84,6 +84,48 @@ the root AGENTS.md.
 
 </Steps>
 
+<WhatToAssert>
+
+Each spec file has a distinct job; keep assertions in the right one:
+
+- **Functional spec** (`showcase.spec.ts`): user flows only — navigation,
+  URL changes, real store/toast/state wiring on a live page. Copy coverage
+  and per-variant semantics belong in Vitest (`add-web-test`), not here.
+- **Layout spec** (`layout.spec.ts`): geometry invariants only. At most one
+  copy assertion per route — the `h1` anchor that proves the page loaded.
+  If you are asserting text beyond that, it is in the wrong file.
+- **VRT spec** (`vrt.spec.ts`): appearance. The work goes into determinism:
+  a `ready` that resolves all streamed/async content, and `mask` for
+  anything inherently unstable (clocks, avatars, live data).
+
+**In-page layout** (component placement, spacing, grid collapse) is covered
+in two tiers:
+
+1. **VRT is the default owner.** A new route's `shots` entries cover its
+   internal arrangement automatically — per viewport and color scheme, so
+   breakpoint collapse regressions show up as image diffs. No extra work.
+2. **Promote critical contracts to geometry.** If a specific arrangement
+   breaking would make the page unusable (e.g. "cards form 2 columns at
+   desktop, 1 on mobile", "the CTA stays inside the viewport"), add a
+   route-specific `boundingBox` assertion in `layout.spec.ts` so the
+   contract has a name and a precise failure message.
+
+Rule of thumb: if a human seeing the broken screenshot would instantly say
+"don't merge", VRT suffices. If the regression might be mistaken for an
+intentional restyle in an image diff, pin it with a geometry assertion.
+
+Routing by change type:
+
+| Change | Touch |
+| --- | --- |
+| New route | `routes` in `layout.spec.ts` + `shots` in `vrt.spec.ts` |
+| New chrome / layout primitive | Helper in `@workspace/playwright` + specs |
+| New interaction flow | Functional spec (+ Vitest for component behavior) |
+| Critical in-page arrangement | Route-specific assertion in `layout.spec.ts` |
+| Style-only change | No new tests — refresh VRT baselines via the workflow |
+
+</WhatToAssert>
+
 <Verify>
 
 - `nps test.web.e2e.all` — all viewport projects (VRT skips off-Linux).

--- a/.opencode/skills/add-e2e-test/SKILL.md
+++ b/.opencode/skills/add-e2e-test/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: add-e2e-test
+description: Use when adding or updating Playwright E2E coverage for a browser app — functional flows, layout geometry invariants (overflow, chrome, scrolling, snap), or visual regression (VRT) baselines — and when wiring a new route or a new browser app into the E2E safety net. Covers the @workspace/playwright config factory and helpers, the layout.spec.ts / vrt.spec.ts patterns, Linux-only VRT baselines, and the "Update VRT baselines" workflow. Trigger keywords: "e2e", "playwright", "layout test", "geometry invariant", "VRT", "visual regression", "screenshot test", "baseline".
+license: MIT
+compatibility: opencode
+metadata:
+  category: implementation
+  package: web,playwright
+  stack: playwright,chromium,next16
+---
+
+<Goal>
+
+Add Playwright E2E coverage that actually catches layout and visual
+regressions. Functional flows prove the app works; geometry invariants prove
+it is not visually broken; VRT proves it still looks the same. Every route
+must be covered by all three, at every viewport project.
+
+</Goal>
+
+<Background>
+
+jsdom computes no CSS layout, and `toBeVisible()` passes on visually broken
+pages. Layout regressions (overflow, wrong chrome per breakpoint, broken
+scrolling, covered content, theme glitches) are only observable in a real
+browser — that is what this layer is for. See "Test Layer Responsibilities" in
+the root AGENTS.md.
+
+</Background>
+
+<Scope>
+
+- Shared infra: `packages/playwright` (`@workspace/playwright`)
+  - `createPlaywrightConfig()` — viewport projects (`desktop` / `tablet` /
+    `mobile`), local `next start` server, VRT tolerances.
+  - Geometry helpers: `expectNoHorizontalOverflow`, `expectExactlyOneVisible`,
+    `expectNoOverlap`, `expectScreenOwnsScroll`, `expectSectionsFillScreen`.
+  - VRT helpers: `vrt`, `isVrtPlatform`, `isVrtUpdate`, `hasVrtBaselines`.
+- App specs: `apps/web/e2e/`
+  - `showcase.spec.ts` — functional flows (navigation, interaction, state).
+  - `layout.spec.ts` — geometry invariants per route x viewport.
+  - `vrt.spec.ts` — screenshot comparison per route x viewport x color scheme.
+- Baselines: `apps/web/e2e/vrt.spec.ts-snapshots/` (Linux-rendered, committed).
+- Baseline refresh: `.github/workflows/update-vrt-baselines.yml`
+  (workflow_dispatch → PR with regenerated images).
+
+</Scope>
+
+<Steps>
+
+1. **New route?** Add it to BOTH route lists:
+   - `layout.spec.ts` `routes` array (path + a stable `h1` heading text), and
+   - `vrt.spec.ts` `shots` array (path, slug, and a `ready` function that
+     waits until the page is deterministic — resolve all Suspense/streamed
+     content before capturing).
+
+2. **New layout contract?** Prefer an existing helper from
+   `@workspace/playwright`; add a new helper there (not inline in the spec)
+   when a second app could need it. Helpers assert real geometry
+   (`boundingBox`, `scrollWidth`, `scrollTop` probes) — never class names.
+   Gotchas encoded in the helpers: `scroll-smooth` makes `scrollTop` reads
+   stale and `snap-mandatory` snaps small offsets back to 0, so probes must
+   force `scroll-behavior: auto` / `scroll-snap-type: none` temporarily;
+   `boundingBox()` throws on never-attached locators (guard with `count()`).
+
+3. **VRT capture rules**: use the `vrt(page, name)` helper (waits for fonts
+   and images); wait for streamed/async content in `ready` first; drive dark
+   mode via `page.emulateMedia({ colorScheme: 'dark' })` (next-themes follows
+   the system scheme). Never capture non-deterministic content — wait for it
+   to settle or `mask` it.
+
+4. **Baselines**: VRT compares only on Linux (`isVrtPlatform`) because font
+   rasterization differs per OS; other platforms skip. After adding shots or
+   landing an intentional visual change, run the **"Update VRT baselines"**
+   workflow (Actions → workflow_dispatch) and merge the PR it opens. Until
+   baselines exist for the spec, it skips (`hasVrtBaselines`) instead of
+   failing.
+
+5. **New browser app?** Call `createPlaywrightConfig()` from the app's
+   `playwright.config.ts` with a distinct `portEnvVar` / `defaultPort` (Turbo
+   runs E2E tasks concurrently), define `test:e2e` in its `package.json`, and
+   create the same three spec files. Add `@workspace/playwright` to its
+   `devDependencies` so `turbo prune` keeps it in CI.
+
+</Steps>
+
+<Verify>
+
+- `nps test.web.e2e.all` — all viewport projects (VRT skips off-Linux).
+- `npx turbo run test:e2e --filter=web -- e2e/layout.spec.ts` — single spec.
+- CI: the `e2e` job in `.github/workflows/tests.yml` runs everything on Linux,
+  including VRT once baselines are committed.
+
+</Verify>
+
+<AntiPatterns>
+
+- Do NOT assert layout in Vitest/jsdom (class names, "should be visible"
+  styling claims) — jsdom cannot see layout; put it in `layout.spec.ts`.
+- Do NOT write screenshot assertions outside the `vrt` helper / tolerances —
+  ad-hoc `toHaveScreenshot` calls without the fonts/images wait flake.
+- Do NOT generate or commit VRT baselines from macOS/Windows — they will fail
+  in CI; only the workflow (Linux) produces valid baselines.
+- Do NOT add a route without extending BOTH `layout.spec.ts` and
+  `vrt.spec.ts` — an uncovered route reintroduces the "tests pass but layout
+  breaks" gap this layer exists to close.
+- Do NOT hand-copy config between apps — extend `createPlaywrightConfig()`.
+
+</AntiPatterns>

--- a/.opencode/skills/add-web-test/SKILL.md
+++ b/.opencode/skills/add-web-test/SKILL.md
@@ -15,6 +15,11 @@ Add a Vitest + jsdom test for `apps/web` that renders components through the
 project's `customRender` wrapper (so router, Redux, and theme context are all
 present) and correctly handles async server components.
 
+**Boundary**: this layer verifies semantics and behavior only. jsdom computes
+no CSS layout — never assert layout, breakpoints, scrolling, or visual
+correctness here; that belongs to the Playwright layers (`add-e2e-test`
+skill: `e2e/layout.spec.ts` geometry invariants and `e2e/vrt.spec.ts` VRT).
+
 </Goal>
 
 <Scope>

--- a/.opencode/skills/add-web-test/SKILL.md
+++ b/.opencode/skills/add-web-test/SKILL.md
@@ -87,6 +87,31 @@ skill: `e2e/layout.spec.ts` geometry invariants and `e2e/vrt.spec.ts` VRT).
 
 </Steps>
 
+<WhatToAssert>
+
+What belongs in a jsdom test, by subject. Everything visual belongs to the
+Playwright layers (`add-e2e-test`) — jsdom computes no CSS layout, so a
+layout assertion here tests nothing.
+
+- **Component** (`_components/`, `@workspace/ui`): roles, ARIA attributes,
+  accessible names; the *semantic* difference between variants (e.g. a
+  `floating` nav renders `sr-only` labels, an active tab gets
+  `aria-current`); handler wiring (click/submit fires, dispatches); controlled
+  state transitions. DOM *order* is fine (`getAllByRole` sequence) — DOM
+  *position* is not.
+- **Page** (async server component): the `h1` and load-bearing copy; link
+  `href`s; semantic attributes the E2E layer anchors on (`data-mode`,
+  `data-slot`, `data-variant`); that awaited `params`/`searchParams` are
+  reflected in output.
+- **Slice / util / hook**: pure input→output — reducers, actions, selectors,
+  formatting; no DOM at all.
+- **Interaction** (form, counter, toast): the component-level behavior here
+  (state updates, callbacks, a11y of error states); the real end-to-end
+  wiring (route + store + toaster on a live page) belongs in the functional
+  E2E spec.
+
+</WhatToAssert>
+
 <Verify>
 
 - `cd apps/web && pnpm test -- path/to/test.test.tsx` — single file
@@ -106,5 +131,9 @@ skill: `e2e/layout.spec.ts` geometry invariants and `e2e/vrt.spec.ts` VRT).
 - Do NOT add `matchMedia` / `IntersectionObserver` / `next/router` mocks
   per-test — they belong in `src/tests/vitest.setup.js`.
 - Do NOT put tests outside `src/tests/` — that's the configured glob.
+- Do NOT assert appearance or placement in jsdom: no `toHaveClass` for
+  styling, no layout/breakpoint/alignment/column-count claims, no full-tree
+  snapshots. Placement and looks are owned by `e2e/layout.spec.ts` (geometry)
+  and `e2e/vrt.spec.ts` (pixels) — see the `add-e2e-test` skill.
 
 </AntiPatterns>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,28 @@ databases, temporary files, and external services. Keep side-effecting external
 checks in an opt-in `test:live` script; never include live tests in default or
 required CI commands.
 
+## Test Layer Responsibilities
+
+Each test layer owns a distinct failure class; put every assertion in the layer
+that can actually observe the failure it guards against:
+
+- **Vitest (jsdom)** — semantics and behavior only: roles, ARIA, copy,
+  interactions, reducers. jsdom computes no CSS layout, so these tests must
+  never claim layout or visual correctness.
+- **Playwright geometry invariants** (`e2e/layout.spec.ts` + the
+  `@workspace/playwright` helpers) — layout contracts measured in real
+  Chromium: no horizontal overflow, exactly one primary nav per viewport,
+  Screen-owned scrolling, chrome never covering content, full/snap sections
+  filling the screen.
+- **Playwright VRT** (`e2e/vrt.spec.ts`) — pixel comparison against committed
+  baselines per route x viewport x color scheme. Baselines render on Linux
+  (CI) only; regenerate them with the "Update VRT baselines" workflow.
+
+**Definition of done**: a change touching layout, chrome, breakpoints, or
+theming is not covered until a geometry invariant and/or VRT shot exercises
+it — passing functional tests alone prove nothing about layout. Follow the
+`add-e2e-test` skill when adding routes or browser apps.
+
 ## App- and Package-specific Guidelines
 
 For app- and package-specific guidelines, see @apps/web/AGENTS.md and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,9 @@ that can actually observe the failure it guards against:
 **Definition of done**: a change touching layout, chrome, breakpoints, or
 theming is not covered until a geometry invariant and/or VRT shot exercises
 it — passing functional tests alone prove nothing about layout. Follow the
-`add-e2e-test` skill when adding routes or browser apps.
+`add-e2e-test` skill when adding routes or browser apps. Per-subject
+assertion placement (component / page / slice / flow → which layer asserts
+what) is detailed in the `add-web-test` and `add-e2e-test` skills.
 
 ## App- and Package-specific Guidelines
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -129,6 +129,15 @@ src/
 
 Tests are located in `src/tests/**/*.test.tsx` using Vitest + jsdom.
 
+Three layers with distinct responsibilities (see the root AGENTS.md "Test
+Layer Responsibilities"): Vitest/jsdom for semantics and behavior (never
+layout), `e2e/layout.spec.ts` for geometry invariants via the
+`@workspace/playwright` helpers, and `e2e/vrt.spec.ts` for visual regression
+against Linux-rendered baselines (skipped locally on other platforms; refresh
+via the "Update VRT baselines" workflow). New routes must be added to the
+route lists in both `e2e/layout.spec.ts` and `e2e/vrt.spec.ts` — the
+`add-e2e-test` skill covers the workflow.
+
 Run tests with:
 
 - `nps test.web` / `nps test.web.unit` - Run Vitest unit/component tests

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test, type Page } from '@playwright/test';
+import {
+  expectExactlyOneVisible,
+  expectNoHorizontalOverflow,
+  expectNoOverlap,
+  expectScreenOwnsScroll,
+  expectSectionsFillScreen,
+} from '@workspace/playwright';
+
+/**
+ * Layout invariants — geometry contracts that must hold on every route at
+ * every viewport project. Functional specs (see showcase.spec.ts) prove the
+ * app works; these prove it is not visually broken. They run in real Chromium,
+ * so breakpoint, overflow, scroll-ownership, and chrome-overlap regressions
+ * fail here even though jsdom unit tests cannot see them.
+ */
+
+const routes = [
+  { path: '/', heading: 'Build from a stronger starting point.' },
+  { path: '/showcase', heading: 'Built to be touched.' },
+  { path: '/showcase/streaming', heading: 'Watch the server arrive in stages.' },
+] as const;
+
+const toolbar = (page: Page) => page.locator('header[data-variant]');
+const bottomNav = (page: Page) => page.locator('nav[data-variant]');
+const screen = (page: Page) => page.locator('main[data-mode]');
+
+for (const { path, heading } of routes) {
+  test.describe(`layout invariants: ${path}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(path);
+      await expect(page.getByRole('heading', { name: heading })).toBeVisible();
+    });
+
+    test('never overflows horizontally', async ({ page }) => {
+      await expectNoHorizontalOverflow(page);
+    });
+
+    test('shows exactly one primary navigation for the viewport', async ({ page }) => {
+      await expectExactlyOneVisible([toolbar(page), bottomNav(page)], 'Toolbar / BottomNav');
+    });
+
+    test('screen owns scrolling, not the window', async ({ page }) => {
+      await expectScreenOwnsScroll(page);
+    });
+
+    test('chrome never covers content at either end of the scroll', async ({ page }) => {
+      // Top: the (possibly floating) toolbar must not sit on the page heading.
+      await expectNoOverlap(toolbar(page), page.getByRole('heading', { name: heading }), {
+        label: 'Toolbar vs page heading',
+      });
+
+      // Bottom: after scrolling to the end, the (possibly floating) bottom nav
+      // must not cover the footer — the Screen spacer must keep it clear.
+      await screen(page).evaluate((el) => {
+        el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+      });
+      await expectNoOverlap(bottomNav(page), page.locator('footer'), {
+        label: 'BottomNav vs footer',
+      });
+    });
+  });
+}
+
+test.describe('layout invariants: snap mode', () => {
+  test('showcase snap sections each fill the screen', async ({ page }) => {
+    await page.goto('/showcase');
+    await expect(page.getByRole('heading', { name: 'Built to be touched.' })).toBeVisible();
+    await expectSectionsFillScreen(page);
+  });
+});

--- a/apps/web/e2e/vrt.spec.ts
+++ b/apps/web/e2e/vrt.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test, type Page } from '@playwright/test';
+import { hasVrtBaselines, isVrtPlatform, isVrtUpdate, vrt } from '@workspace/playwright';
+
+/**
+ * Visual regression — pixel-level comparison against committed baselines for
+ * every route × viewport project × color scheme. Catches what geometry
+ * invariants cannot: colors, typography, spacing, borders, shadows, and
+ * dark-mode rendering.
+ *
+ * Baselines live in `vrt.spec.ts-snapshots/` and are rendered on Linux (CI)
+ * only — font rasterization differs per OS, so other platforms skip. To
+ * create or refresh baselines, run the "Update VRT baselines" workflow
+ * (workflow_dispatch), which opens a PR with the regenerated images.
+ */
+
+const shots: ReadonlyArray<{
+  path: string;
+  slug: string;
+  ready: (page: Page) => Promise<void>;
+}> = [
+  {
+    path: '/',
+    slug: 'home',
+    ready: async (page) => {
+      await expect(
+        page.getByRole('heading', { name: 'Build from a stronger starting point.' }),
+      ).toBeVisible();
+    },
+  },
+  {
+    path: '/showcase',
+    slug: 'showcase',
+    ready: async (page) => {
+      await expect(page.getByRole('heading', { name: 'Built to be touched.' })).toBeVisible();
+    },
+  },
+  {
+    path: '/showcase/streaming',
+    slug: 'streaming',
+    ready: async (page) => {
+      // Wait for both Suspense boundaries to resolve so the capture is
+      // deterministic (the payloads stream in after 800ms / 1800ms).
+      await expect(page.getByText('Primary payload arrived')).toBeVisible();
+      await expect(page.getByText('Secondary payload arrived')).toBeVisible();
+    },
+  },
+];
+
+test.describe('visual regression', () => {
+  test.skip(!isVrtPlatform, 'VRT baselines are rendered on Linux (CI); skipped elsewhere.');
+  test.skip(
+    isVrtPlatform && !isVrtUpdate && !hasVrtBaselines(__filename),
+    'No committed VRT baselines yet — run the "Update VRT baselines" workflow.',
+  );
+
+  for (const colorScheme of ['light', 'dark'] as const) {
+    for (const { path, slug, ready } of shots) {
+      test(`${slug} (${colorScheme})`, async ({ page }) => {
+        await page.emulateMedia({ colorScheme });
+        await page.goto(path);
+        await ready(page);
+        await vrt(page, `${slug}-${colorScheme}.png`);
+      });
+    }
+  }
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@workspace/eslint": "workspace:*",
+    "@workspace/playwright": "workspace:*",
     "@workspace/prettier": "workspace:*",
     "@workspace/tsconfig": "workspace:*",
     "@workspace/types": "workspace:*",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,3 +1,3 @@
-import { createPlaywrightConfig } from './playwright.shared';
+import { createPlaywrightConfig } from '@workspace/playwright';
 
 export default createPlaywrightConfig();

--- a/apps/web/playwright.live.config.ts
+++ b/apps/web/playwright.live.config.ts
@@ -1,3 +1,3 @@
-import { createPlaywrightConfig } from './playwright.shared';
+import { createPlaywrightConfig } from '@workspace/playwright';
 
 export default createPlaywrightConfig({ live: true });

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -1,0 +1,43 @@
+# Playwright
+
+This package provides the shared Playwright configuration and the
+layout-regression test helpers for browser apps in the monorepo.
+
+## Overview
+
+- `config.ts` — `createPlaywrightConfig()` factory: the three standard viewport
+  projects (`desktop` / `tablet` / `mobile`), the local `next start` web
+  server, reporters/artifacts, and screenshot-comparison tolerances.
+- `layout.ts` — geometry invariant assertions (`expectNoHorizontalOverflow`,
+  `expectExactlyOneVisible`, `expectNoOverlap`, `expectScreenOwnsScroll`,
+  `expectSectionsFillScreen`). jsdom cannot compute CSS layout and
+  `toBeVisible()` passes on visually broken pages; these helpers assert the
+  layout contracts directly from real browser geometry.
+- `vrt.ts` — visual-regression helpers (`vrt`, `isVrtPlatform`,
+  `hasVrtBaselines`, `isVrtUpdate`). Baselines are rendered on Linux (CI)
+  only; other platforms skip.
+
+## Usage
+
+```ts
+// playwright.config.ts
+import { createPlaywrightConfig } from '@workspace/playwright';
+
+export default createPlaywrightConfig();
+```
+
+```ts
+// e2e/layout.spec.ts
+import { test } from '@playwright/test';
+import { expectNoHorizontalOverflow, expectScreenOwnsScroll } from '@workspace/playwright';
+
+test('home keeps its layout invariants', async ({ page }) => {
+  await page.goto('/');
+  await expectNoHorizontalOverflow(page);
+  await expectScreenOwnsScroll(page);
+});
+```
+
+New browser apps must pass a distinct `portEnvVar` / `defaultPort` so Turbo can
+run E2E tasks concurrently. See the `add-e2e-test` skill for the full workflow,
+including how VRT baselines are generated and updated.

--- a/packages/playwright/config.ts
+++ b/packages/playwright/config.ts
@@ -1,13 +1,38 @@
 import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test';
 
-interface PlaywrightConfigOptions {
+export interface PlaywrightConfigOptions {
+  /**
+   * Run against an external deployment (`PLAYWRIGHT_BASE_URL`) instead of
+   * starting a local production server.
+   */
   live?: boolean;
+  /**
+   * Environment variable that holds the local E2E port. Every browser app must
+   * own a distinct variable + default so Turbo can run E2E tasks concurrently.
+   */
+  portEnvVar?: string;
+  /** Default local E2E port when the env var is unset. */
+  defaultPort?: number;
+  /** Local server command factory. Defaults to `next start` on the given port. */
+  serverCommand?: (port: number) => string;
 }
 
+/**
+ * Shared Playwright config factory for workspace browser apps.
+ *
+ * Owns the three standard viewport projects (desktop / tablet / mobile), the
+ * local `next start` web server, reporter/artifact settings, and the
+ * screenshot-comparison tolerances used by the VRT helpers. Apps create their
+ * `playwright.config.ts` by calling this factory so every fork inherits the
+ * same layout-regression safety net.
+ */
 export const createPlaywrightConfig = ({
   live = false,
+  portEnvVar = 'WEB_E2E_PORT',
+  defaultPort = 3100,
+  serverCommand = (port) => `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
 }: PlaywrightConfigOptions = {}): PlaywrightTestConfig => {
-  const port = live ? undefined : Number(process.env.WEB_E2E_PORT ?? 3100);
+  const port = live ? undefined : Number(process.env[portEnvVar] ?? defaultPort);
   const externalBaseURL = live ? process.env.PLAYWRIGHT_BASE_URL : undefined;
 
   if (live && !externalBaseURL) {
@@ -15,7 +40,7 @@ export const createPlaywrightConfig = ({
   }
 
   if (!live && (!Number.isInteger(port) || port! < 1 || port! > 65_535)) {
-    throw new Error('WEB_E2E_PORT must be a valid TCP port.');
+    throw new Error(`${portEnvVar} must be a valid TCP port.`);
   }
 
   const baseURL = live ? externalBaseURL! : `http://127.0.0.1:${port}`;
@@ -30,6 +55,15 @@ export const createPlaywrightConfig = ({
     reporter: process.env.CI
       ? [['line'], ['html', { open: 'never', outputFolder: reportFolder }]]
       : [['html', { open: 'never', outputFolder: reportFolder }]],
+    expect: {
+      // Visual-regression comparisons (see vrt.ts). Small ratio tolerance
+      // absorbs anti-aliasing noise; anything visible to a human still fails.
+      toHaveScreenshot: {
+        maxDiffPixelRatio: 0.01,
+        animations: 'disabled',
+        caret: 'hide',
+      },
+    },
     use: {
       baseURL,
       screenshot: 'only-on-failure',
@@ -63,7 +97,7 @@ export const createPlaywrightConfig = ({
     webServer: live
       ? undefined
       : {
-          command: `pnpm exec next start --hostname 127.0.0.1 --port ${port}`,
+          command: serverCommand(port!),
           url: baseURL,
           reuseExistingServer: false,
           timeout: 120_000,

--- a/packages/playwright/index.ts
+++ b/packages/playwright/index.ts
@@ -1,0 +1,9 @@
+export { createPlaywrightConfig, type PlaywrightConfigOptions } from './config';
+export {
+  expectExactlyOneVisible,
+  expectNoHorizontalOverflow,
+  expectNoOverlap,
+  expectScreenOwnsScroll,
+  expectSectionsFillScreen,
+} from './layout';
+export { hasVrtBaselines, isVrtPlatform, isVrtUpdate, vrt } from './vrt';

--- a/packages/playwright/layout.ts
+++ b/packages/playwright/layout.ts
@@ -1,0 +1,139 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Geometry invariants for layout-regression E2E tests.
+ *
+ * jsdom unit tests cannot compute CSS layout, and plain `toBeVisible()` checks
+ * pass even when the page is visually broken. These helpers assert the layout
+ * contracts that keep a page usable — run them per route, per viewport
+ * project, so breakpoint regressions surface in CI.
+ */
+
+/** The app must never overflow horizontally at any viewport. */
+export const expectNoHorizontalOverflow = async (page: Page) => {
+  const overflow = await page.evaluate(() => {
+    const el = document.documentElement;
+    return el.scrollWidth - el.clientWidth;
+  });
+  expect(overflow, 'document must not overflow horizontally').toBeLessThanOrEqual(0);
+};
+
+/**
+ * Exactly one of the given locators must be visible — e.g. the responsive
+ * chrome contract: Toolbar (sm+) XOR BottomNav (mobile), never both or none.
+ */
+export const expectExactlyOneVisible = async (locators: Locator[], label = 'locators') => {
+  const visibilities = await Promise.all(locators.map((locator) => locator.isVisible()));
+  const visibleCount = visibilities.filter(Boolean).length;
+  expect(visibleCount, `exactly one of ${label} must be visible (got ${visibleCount})`).toBe(1);
+};
+
+/**
+ * Two elements must not overlap (e.g. floating chrome vs. content/CTAs).
+ * Elements that are not rendered pass trivially. `tolerance` allows a few
+ * pixels of intentional visual overlap (shadows, rounded corners).
+ */
+export const expectNoOverlap = async (
+  a: Locator,
+  b: Locator,
+  { tolerance = 0, label = 'elements' }: { tolerance?: number; label?: string } = {},
+) => {
+  // Absent or hidden elements cannot overlap; `boundingBox()` alone would
+  // throw on locators that never attach.
+  const box = async (locator: Locator) =>
+    (await locator.count()) === 0 ? null : await locator.boundingBox();
+  const [boxA, boxB] = await Promise.all([box(a), box(b)]);
+  if (!boxA || !boxB) return;
+
+  const xOverlap = Math.min(boxA.x + boxA.width, boxB.x + boxB.width) - Math.max(boxA.x, boxB.x);
+  const yOverlap = Math.min(boxA.y + boxA.height, boxB.y + boxB.height) - Math.max(boxA.y, boxB.y);
+  const overlaps = xOverlap > tolerance && yOverlap > tolerance;
+  expect(
+    overlaps,
+    `${label} must not overlap (x: ${Math.round(xOverlap)}px, y: ${Math.round(yOverlap)}px)`,
+  ).toBe(false);
+};
+
+/**
+ * The window/body must never scroll; the `Screen` region owns scrolling.
+ * Catches lost `overflow-hidden` / `h-svh` / `min-h-0` on the app shell,
+ * which shows up as double scrollbars or a chrome that scrolls away.
+ */
+export const expectScreenOwnsScroll = async (page: Page, screenSelector = 'main[data-mode]') => {
+  const result = await page.evaluate((selector) => {
+    window.scrollTo({ top: 120, behavior: 'instant' });
+    const windowScrolled = window.scrollY;
+    window.scrollTo({ top: 0, behavior: 'instant' });
+
+    const screen = document.querySelector<HTMLElement>(selector);
+    if (!screen) return { windowScrolled, screenFound: false, screenScrolls: null };
+
+    // Only assert scrollability when there is actually overflowing content.
+    if (screen.scrollHeight <= screen.clientHeight + 1) {
+      return { windowScrolled, screenFound: true, screenScrolls: null };
+    }
+    // `scroll-smooth` screens report a stale scrollTop right after the
+    // assignment, and `snap-mandatory` screens snap small offsets back to 0 —
+    // neutralize both for the probe, then restore.
+    const previousBehavior = screen.style.scrollBehavior;
+    const previousSnapType = screen.style.scrollSnapType;
+    screen.style.scrollBehavior = 'auto';
+    screen.style.scrollSnapType = 'none';
+    const before = screen.scrollTop;
+    screen.scrollTop = 120;
+    const screenScrolls = screen.scrollTop > 0;
+    screen.scrollTop = before;
+    screen.style.scrollBehavior = previousBehavior;
+    screen.style.scrollSnapType = previousSnapType;
+    return { windowScrolled, screenFound: true, screenScrolls };
+  }, screenSelector);
+
+  expect(result.screenFound, `Screen (${screenSelector}) must exist`).toBe(true);
+  expect(result.windowScrolled, 'window/body must not scroll — Screen owns scrolling').toBe(0);
+  if (result.screenScrolls !== null) {
+    expect(result.screenScrolls, 'Screen must be able to scroll its overflowing content').toBe(
+      true,
+    );
+  }
+};
+
+/**
+ * In `full` / `snap` mode every `Section` must fill the visible scroll region.
+ * Catches sections that stop filling the viewport after a flex/height change.
+ */
+export const expectSectionsFillScreen = async (
+  page: Page,
+  {
+    screenSelector = 'main[data-mode]',
+    sectionSelector = '[data-slot="section"]',
+    tolerance = 1,
+  }: { screenSelector?: string; sectionSelector?: string; tolerance?: number } = {},
+) => {
+  const result = await page.evaluate(
+    ({ screenSelector, sectionSelector }) => {
+      const screen = document.querySelector(screenSelector);
+      if (!screen) return null;
+      return {
+        mode: screen.getAttribute('data-mode'),
+        screenHeight: screen.clientHeight,
+        sectionHeights: [...screen.querySelectorAll(sectionSelector)].map(
+          (section) => section.getBoundingClientRect().height,
+        ),
+      };
+    },
+    { screenSelector, sectionSelector },
+  );
+
+  expect(result, `Screen (${screenSelector}) must exist`).not.toBeNull();
+  expect(
+    ['full', 'snap'],
+    'expectSectionsFillScreen only applies to full/snap Screen modes',
+  ).toContain(result!.mode);
+  expect(result!.sectionHeights.length, 'Screen must contain sections').toBeGreaterThan(0);
+  for (const [index, height] of result!.sectionHeights.entries()) {
+    expect(
+      height,
+      `section #${index} must fill the ${result!.screenHeight}px screen (got ${Math.round(height)}px)`,
+    ).toBeGreaterThanOrEqual(result!.screenHeight - tolerance);
+  }
+};

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@workspace/playwright",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./index.ts",
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
+  }
+}

--- a/packages/playwright/vrt.ts
+++ b/packages/playwright/vrt.ts
@@ -1,0 +1,58 @@
+import { existsSync } from 'node:fs';
+import {
+  expect,
+  type Page,
+  type PageAssertionsToHaveScreenshotOptions,
+} from '@playwright/test';
+
+/**
+ * Visual-regression testing (VRT) helpers.
+ *
+ * Baselines are rendered on Linux (CI): font rasterization differs per OS, so
+ * comparing a macOS render against a Linux baseline flakes. Specs must gate on
+ * `isVrtPlatform` (and on committed baselines — see `hasVrtBaselines`) so
+ * local runs on other platforms skip instead of failing.
+ */
+
+/** True where VRT baselines are rendered and compared (Linux, i.e. CI). */
+export const isVrtPlatform = process.platform === 'linux';
+
+/**
+ * Whether committed baselines exist for a spec file (Playwright keeps them in
+ * a sibling `<spec>-snapshots` directory). Before the first baseline PR lands,
+ * specs skip instead of failing on "snapshot missing".
+ */
+export const hasVrtBaselines = (specFilePath: string) => existsSync(`${specFilePath}-snapshots`);
+
+/**
+ * True when the update-baselines workflow is running (`VRT_UPDATE=1`), which
+ * must not skip on missing baselines — it creates them.
+ */
+export const isVrtUpdate = process.env.VRT_UPDATE === '1';
+
+/**
+ * Capture a stable screenshot and compare it against the committed baseline.
+ * Waits for fonts and images so the capture is deterministic; tolerances and
+ * animation-freezing come from the shared config factory.
+ */
+export const vrt = async (
+  page: Page,
+  name: string,
+  options?: PageAssertionsToHaveScreenshotOptions,
+) => {
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await Promise.all(
+      [...document.images]
+        .filter((img) => !img.complete)
+        .map(
+          (img) =>
+            new Promise((resolve) => {
+              img.addEventListener('load', resolve, { once: true });
+              img.addEventListener('error', resolve, { once: true });
+            }),
+        ),
+    );
+  });
+  await expect(page).toHaveScreenshot(name, options);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@workspace/eslint':
         specifier: workspace:*
         version: link:../../packages/eslint
+      '@workspace/playwright':
+        specifier: workspace:*
+        version: link:../../packages/playwright
       '@workspace/prettier':
         specifier: workspace:*
         version: link:../../packages/prettier
@@ -196,6 +199,12 @@ importers:
       typescript-eslint:
         specifier: ^8.15.0
         version: 8.61.1(@typescript/typescript6@6.0.2)(eslint@9.39.4(jiti@2.7.0))
+
+  packages/playwright:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
 
   packages/prettier:
     devDependencies:


### PR DESCRIPTION
## Overview

Add a reusable layout-regression testing foundation so this starter and its downstream forks catch visual breakage that functional tests cannot observe.

## Changes

### Shared Playwright foundation

- Promote the Playwright config factory to `@workspace/playwright`.
- Add reusable assertions for overflow, responsive chrome, overlap, scroll ownership, and full/snap sections.
- Add deterministic, Linux-gated VRT capture helpers.

### Layout and visual regression coverage

- Exercise home, showcase, and streaming routes across desktop, tablet, and mobile viewport projects.
- Compare each route in light and dark color schemes against committed Linux baselines.
- Add a manually dispatched workflow that regenerates baselines and opens an update PR.

### Testing standards

- Define the responsibilities of Vitest semantics, Playwright geometry invariants, and VRT.
- Add subject-specific assertion guidance for components, pages, state, user flows, and in-page layout.
- Add an `add-e2e-test` skill and clarify the jsdom boundary in `add-web-test`.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

- `npx nps lint`
- `npx nps typecheck`
- `npx nps test.web.unit`
- `npx nps test.web.e2e.all` (42 passed, 18 VRT cases skipped as expected on macOS)

## Screenshots

Not applicable. This PR adds the infrastructure that produces and compares visual baselines.

## Notes

After merge, run the **Update VRT baselines** workflow once and merge its generated PR to seed the initial Linux/Chromium baselines and activate VRT comparisons in regular CI.
