### PR TITLE
Fix VRT baseline image waits

### DIFF
--- a/.github/workflows/update-vrt-baselines.yml
+++ b/.github/workflows/update-vrt-baselines.yml
@@ -51,6 +51,16 @@ jobs:
         env:
           VRT_UPDATE: "1"
         run: pnpm exec playwright test e2e/vrt.spec.ts --update-snapshots
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vrt-baseline-artifacts
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/packages/playwright/vrt.ts
+++ b/packages/playwright/vrt.ts
@@ -32,8 +32,15 @@ export const isVrtUpdate = process.env.VRT_UPDATE === '1';
 
 /**
  * Capture a stable screenshot and compare it against the committed baseline.
- * Waits for fonts and images so the capture is deterministic; tolerances and
- * animation-freezing come from the shared config factory.
+ * Waits for fonts and in-viewport images so the capture is deterministic;
+ * tolerances and animation-freezing come from the shared config factory.
+ *
+ * Only images intersecting the viewport are awaited: shots are viewport-sized,
+ * so off-screen images cannot affect them — and `loading="lazy"` images below
+ * the fold (Next.js `<Image>` default) never fire `load` at all, which would
+ * hang an unconditional wait (seen on the narrow mobile project). A hard cap
+ * bounds the whole wait so no pathological asset can hold the capture until
+ * the test timeout.
  */
 export const vrt = async (
   page: Page,
@@ -41,18 +48,36 @@ export const vrt = async (
   options?: PageAssertionsToHaveScreenshotOptions,
 ) => {
   await page.evaluate(async () => {
-    await document.fonts.ready;
-    await Promise.all(
-      [...document.images]
-        .filter((img) => !img.complete)
-        .map(
-          (img) =>
-            new Promise((resolve) => {
-              img.addEventListener('load', resolve, { once: true });
-              img.addEventListener('error', resolve, { once: true });
-            }),
-        ),
-    );
+    const capMs = 5_000;
+    const cap = new Promise((resolve) => {
+      setTimeout(resolve, capMs);
+    });
+    const intersectsViewport = (img: HTMLImageElement) => {
+      const rect = img.getBoundingClientRect();
+      return (
+        rect.bottom > 0 &&
+        rect.right > 0 &&
+        rect.top < window.innerHeight &&
+        rect.left < window.innerWidth
+      );
+    };
+    const readiness = async () => {
+      await document.fonts.ready;
+      await Promise.all(
+        [...document.images]
+          .filter((img) => !img.complete && intersectsViewport(img))
+          .map(
+            (img) =>
+              new Promise((resolve) => {
+                img.addEventListener('load', resolve, { once: true });
+                img.addEventListener('error', resolve, { once: true });
+                // The image may finish between the filter and listener setup.
+                if (img.complete) resolve(undefined);
+              }),
+          ),
+      );
+    };
+    await Promise.race([readiness(), cap]);
   });
   await expect(page).toHaveScreenshot(name, options);
 };


### PR DESCRIPTION
## Overview

Fix the mobile timeout in the **Update VRT baselines** workflow introduced by #27. The VRT readiness helper waited for every incomplete image, including below-fold `loading="lazy"` images that never load on narrow viewports.

## Changes

### Fix VRT readiness

- Wait only for incomplete images that intersect the captured viewport.
- Wait for fonts before calculating image visibility.
- Recheck `complete` after listener registration to avoid a load-event race.
- Bound the combined readiness wait to five seconds so an asset cannot hang the test until Playwright's timeout.

### Improve CI diagnostics

- Upload Playwright reports, screenshots, traces, and videos when baseline regeneration fails.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing

- `npx nps lint`
- `npx nps typecheck`
- `npx nps test.web.e2e.mobile` (14 passed, 6 VRT cases skipped as expected on macOS)
- Real Chromium with Pixel 7 and desktop profiles: readiness wait completed for home, showcase, and streaming routes; slowest result was 35ms.

## Screenshots

Not applicable. Failure artifacts will be available from the baseline workflow if CI rendering fails again.

## Notes

After merge, rerun **Update VRT baselines** to generate the initial Linux/Chromium snapshots.

Follow-up to #27.
